### PR TITLE
Generate code for settings page missing the ID

### DIFF
--- a/modules/settings-page/src/Generator.php
+++ b/modules/settings-page/src/Generator.php
@@ -24,7 +24,7 @@ class Generator {
 	public function generate( WP_REST_Request $request ) {
 		$settings = array_merge( [
 			'menu_title' => $request->get_param( 'post_title' ),
-			'id' => ( $request->get_param( 'post_name' ) != "" ) ? $request->get_param( 'post_name' ) : sanitize_title( $request->get_param( 'post_title' ) ),
+			'id' => $request->get_param( 'post_name' ) ?: sanitize_title( $request->get_param( 'post_title' ) ),
 		], $request->get_param( 'settings' ) );
 
 		$parser = new Parser( $settings );


### PR DESCRIPTION
MB Builder: generate code for settings page missing the ID: https://app.asana.com/0/17125277541504/1202039028884818