### PR TITLE
feat: sync attribute name as id

### DIFF
--- a/src/Extensions/Blocks.php
+++ b/src/Extensions/Blocks.php
@@ -91,8 +91,9 @@ class Blocks {
 
 		foreach ( $attributes as $name => $value ) {
 			if ( is_array( $value ) && isset( $value['meta-box-field'] ) ) {
-				$field                 = $value['meta-box-field'];
-				$fields[ $field['_id'] ] = $field;
+				$field                 		= $value['meta-box-field'];
+				$field['id'] 		 		= $name;
+				$fields[ $field['_id'] ] 	= $field;
 			}
 		}
 


### PR DESCRIPTION
Nếu người dùng có attributes như sau
```
{
...
    "attributes": {
        "foo": {
            "type": "string",
            "meta-box-field": {
                "_id": "text_0upvns3o4jv",
                "name": "Text",
                "id": "foo",
                ...
            }
        },
}
```

Hiện tại, nếu sửa id trong meta-box-field thì id của field trong builder cũng tự động được sửa theo.
Tuy nhiên, nếu sửa attributes.foo thì id trong builder sẽ không cập nhật theo.

PR này để sync id trong builder ưu tiên theo attribuites.$id