### PR TITLE
fix: draft field group

### DIFF
--- a/src/AdminColumns.php
+++ b/src/AdminColumns.php
@@ -32,6 +32,40 @@ class AdminColumns {
 		add_filter( 'wp_untrash_post_status', [ $this, 'set_post_status' ], 10, 2 );
 		// Restore posts should restore the json file as well.
 		add_action( 'untrashed_post', [ $this, 'restore_json' ], 10, 1 );
+
+		add_action( 'transition_post_status', [ $this, 'handle_draft_to_publish' ], 10, 3 );
+	}
+
+	public function handle_draft_to_publish( $new_status, $old_status, $post ) {
+		// Bail if LocalJson is not enabled.
+		if ( ! LocalJson::is_enabled() ) {
+			return;
+		}
+
+		if ( $post->post_type !== $this->post_type ) {
+			return;
+		}
+
+		if ( $new_status === 'publish' && $old_status === 'draft' ) {
+			// When switching from 'draft' to 'publish', the earlier meta box does not contains id 
+			// (since draft posts don't have post_name property).
+			// So, we need to set the id for the meta box
+			$meta_box = get_post_meta( $post->ID, 'meta_box', true );
+
+			if ( ! is_array( $meta_box ) ) {
+				return;
+			}
+
+			if ( ! isset( $meta_box['id'] ) ) {
+				$meta_box['id'] = $post->post_name;
+				update_post_meta( $post->ID, 'meta_box', $meta_box );
+			}
+
+			// Publish the json file.
+			LocalJson::use_database( [
+				'post_id' => $post->ID,
+			] );
+		}
 	}
 
 	public function set_post_status( $new_status, $post_id ) {

--- a/src/AdminColumns.php
+++ b/src/AdminColumns.php
@@ -29,22 +29,28 @@ class AdminColumns {
 		add_action( 'wp_trash_post', [ $this, 'delete_json' ], 10, 1 );
 		add_action( 'before_delete_post', [ $this, 'delete_json' ], 10, 1 );
 
-		add_filter( 'wp_untrash_post_status', [ $this, 'set_post_status' ], 10, 1 );
+		add_filter( 'wp_untrash_post_status', [ $this, 'set_post_status' ], 10, 2 );
 		// Restore posts should restore the json file as well.
 		add_action( 'untrashed_post', [ $this, 'restore_json' ], 10, 1 );
 	}
 
-	public function set_post_status( $status ) {
+	public function set_post_status( $new_status, $post_id ) {
 		// Bail if LocalJson is not enabled.
 		if ( ! LocalJson::is_enabled() ) {
-			return $status;
+			return $new_status;
 		}
 
-		if ( $status === 'draft' ) {
+		if ( $new_status === 'draft' ) {
+			$post = get_post( $post_id );
+			
+			if ( $post->post_type !== $this->post_type ) {
+				return $new_status;
+			}
+
 			return 'publish';
 		}
 
-		return $status;
+		return $new_status;
 	}
 
 	public function delete_json( $post_id ) {

--- a/src/Export.php
+++ b/src/Export.php
@@ -48,6 +48,10 @@ class Export {
 			'post_status' => $post_status,
 			'post__in'    => $post_ids,
 		] );
+		
+		if ( empty( $data ) ) {
+			return;
+		}
 
 		// Remove post_id & post_type from the data
 		$data = array_map( function ( $item ) {

--- a/src/JsonService.php
+++ b/src/JsonService.php
@@ -95,6 +95,10 @@ class JsonService {
 		$meta_boxes = self::get_meta_boxes( $params );
 
 		foreach ( $meta_boxes as $meta_box ) {
+			if ( ! isset( $meta_box['id'] ) ) {
+				continue;
+			}
+			
 			$id        = $meta_box['id'];
 			$post_id   = $meta_box['post_id'];
 			$post_type = $meta_box['post_type'];

--- a/src/JsonService.php
+++ b/src/JsonService.php
@@ -205,6 +205,12 @@ class JsonService {
 		$meta_boxes = [];
 		foreach ( $query->posts as $post ) {
 			$post_data = (array) $post;
+
+			// Drafts don't have post_name so we skip them
+			if ( empty( $post_data['post_name'] ) ) {
+				continue;
+			}
+
 			$meta_keys = self::get_related_meta_keys( $query_params['post_type'] );
 
 			foreach ( $meta_keys as $meta_key ) {

--- a/src/JsonService.php
+++ b/src/JsonService.php
@@ -67,6 +67,11 @@ class JsonService {
 			$json            = $unparser->get_settings();
 			$local_minimized = $unparser->to_minimal_format();
 
+			// ID is required so we can compare with the post ID
+			if ( ! isset( $local_minimized['id'] ) ) {
+				continue;
+			}
+
 			$diff = wp_text_diff( '', wp_json_encode( $raw_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ), [
 				'show_split_view' => true,
 			] );

--- a/src/LocalJson.php
+++ b/src/LocalJson.php
@@ -176,7 +176,7 @@ class LocalJson {
 			return false;
 		}
 
-		if ( $post->post_type !== 'meta-box' ) {
+		if ( $post->post_type !== 'meta-box' || $post->post_status !== 'publish' ) {
 			return false;
 		}
 


### PR DESCRIPTION
Khi save draft, WordPress sẽ không lưu `post_name` nên không có meta box id dẫn đến fatal error trong logic, vì không có meta box id nên không thể tạo file json tương ứng nên trường hợp save draft mình sẽ bỏ qua.