### PR TITLE
Fix: Preserve icon_dashicons in SettingsPage Parser

### DIFF
--- a/src/Extensions/SettingsPage/Parser.php
+++ b/src/Extensions/SettingsPage/Parser.php
@@ -74,9 +74,6 @@ class Parser extends Base {
 		}
 		$tabs = [];
 		foreach ( $this->tabs as $tab ) {
-			if ( empty( $tab['key'] ) || empty( $tab['value'] ) ) {
-				continue;
-			}
 			$tabs[ $tab['key'] ] = $tab['value'];
 		}
 		$this->tabs = $tabs;

--- a/src/Extensions/SettingsPage/Parser.php
+++ b/src/Extensions/SettingsPage/Parser.php
@@ -22,7 +22,8 @@ class Parser extends Base {
 
 	private function parse_menu_icon(): self {
 		// Submenu.
-		if ( 'top' !== $this->menu_type ) {
+		$menu_type = Arr::get( $this->settings, 'menu_type', 'top' );
+		if ( 'top' !== $menu_type ) {
 			return $this;
 		}
 

--- a/src/Extensions/SettingsPage/Parser.php
+++ b/src/Extensions/SettingsPage/Parser.php
@@ -29,19 +29,33 @@ class Parser extends Base {
 		// Top level menu.
 		unset( $this->parent );
 
-		// Setup icon URL.
-		$type           = Arr::get( $this->settings, 'icon_type', 'dashicons' );
-		$this->icon_url = Arr::get( $this->settings, "icon_$type" );
-
+		// Setup icon URL based on type.
+		$type = Arr::get( $this->settings, 'icon_type', 'dashicons' );
+		
 		if ( 'dashicons' === $type ) {
+			$this->icon_url = Arr::get( $this->settings, 'icon_dashicons' );
+			// Preserve original icon_dashicons value
+			$this->icon_dashicons = $this->icon_url;
 			$this->icon_url = 'dashicons-' . $this->icon_url;
+		} elseif ( 'font_awesome' === $type ) {
+			$this->icon_url = Arr::get( $this->settings, 'icon_font_awesome' );
+			$this->icon_font_awesome = $this->icon_url;
+		} elseif ( 'svg' === $type ) {
+			$this->icon_url = Arr::get( $this->settings, 'icon_svg' );
+			$this->icon_svg = $this->icon_url;
+		} elseif ( 'custom' === $type ) {
+			$this->icon_url = Arr::get( $this->settings, 'icon_custom' );
+			$this->icon_custom = $this->icon_url;
+		} else {
+			// Fallback to icon_url if set
+			$this->icon_url = Arr::get( $this->settings, 'icon_url' );
 		}
 
 		return $this;
 	}
 
 	private function remove_menu_keys(): self {
-		$keys = [ 'menu_type', 'icon_type', 'icon_dashicons', 'icon_svg', 'icon_custom', 'icon_font_awesome' ];
+		$keys = [ 'menu_type' ];
 		foreach ( $keys as $key ) {
 			unset( $this->$key );
 		}

--- a/src/Extensions/SettingsPage/Parser.php
+++ b/src/Extensions/SettingsPage/Parser.php
@@ -29,33 +29,19 @@ class Parser extends Base {
 		// Top level menu.
 		unset( $this->parent );
 
-		// Setup icon URL based on type.
-		$type = Arr::get( $this->settings, 'icon_type', 'dashicons' );
-		
+		// Setup icon URL.
+		$type           = Arr::get( $this->settings, 'icon_type', 'dashicons' );
+		$this->icon_url = Arr::get( $this->settings, "icon_$type" );
+
 		if ( 'dashicons' === $type ) {
-			$this->icon_url = Arr::get( $this->settings, 'icon_dashicons' );
-			// Preserve original icon_dashicons value
-			$this->icon_dashicons = $this->icon_url;
 			$this->icon_url = 'dashicons-' . $this->icon_url;
-		} elseif ( 'font_awesome' === $type ) {
-			$this->icon_url = Arr::get( $this->settings, 'icon_font_awesome' );
-			$this->icon_font_awesome = $this->icon_url;
-		} elseif ( 'svg' === $type ) {
-			$this->icon_url = Arr::get( $this->settings, 'icon_svg' );
-			$this->icon_svg = $this->icon_url;
-		} elseif ( 'custom' === $type ) {
-			$this->icon_url = Arr::get( $this->settings, 'icon_custom' );
-			$this->icon_custom = $this->icon_url;
-		} else {
-			// Fallback to icon_url if set
-			$this->icon_url = Arr::get( $this->settings, 'icon_url' );
 		}
 
 		return $this;
 	}
 
 	private function remove_menu_keys(): self {
-		$keys = [ 'menu_type' ];
+		$keys = [ 'menu_type', 'icon_type', 'icon_dashicons', 'icon_svg', 'icon_custom', 'icon_font_awesome' ];
 		foreach ( $keys as $key ) {
 			unset( $this->$key );
 		}
@@ -88,6 +74,9 @@ class Parser extends Base {
 		}
 		$tabs = [];
 		foreach ( $this->tabs as $tab ) {
+			if ( empty( $tab['key'] ) || empty( $tab['value'] ) ) {
+				continue;
+			}
 			$tabs[ $tab['key'] ] = $tab['value'];
 		}
 		$this->tabs = $tabs;

--- a/src/Extensions/SettingsPage/Save.php
+++ b/src/Extensions/SettingsPage/Save.php
@@ -44,6 +44,17 @@ class Save {
 		$post_title = $request->get_param( 'post_title' );
 		$settings   = $request->get_param( 'settings' );
 
+		$type     = $settings['icon_type'] ?? '';
+		$default  = 'dashicons-' . ( $settings['icon_dashicons'] ?? '' );
+
+		// If $type is empty ⇒ use default
+		$settings['icon_url'] = empty($type)
+		? $default
+		: ( $type === 'dashicons'
+			? $default
+			: ( $settings['icon_' . $type] ?? $default )
+		);
+		
 		$post_name = sanitize_title( empty( $settings['id'] ) ? $post_title : $settings['id'] );
 
 		$post = get_post( $post_id );

--- a/src/Extensions/SettingsPage/Save.php
+++ b/src/Extensions/SettingsPage/Save.php
@@ -44,17 +44,6 @@ class Save {
 		$post_title = $request->get_param( 'post_title' );
 		$settings   = $request->get_param( 'settings' );
 
-		$type     = $settings['icon_type'] ?? '';
-		$default  = 'dashicons-' . ( $settings['icon_dashicons'] ?? '' );
-
-		// If $type is empty ⇒ use default
-		$settings['icon_url'] = empty($type)
-		? $default
-		: ( $type === 'dashicons'
-			? $default
-			: ( $settings['icon_' . $type] ?? $default )
-		);
-		
 		$post_name = sanitize_title( empty( $settings['id'] ) ? $post_title : $settings['id'] );
 
 		$post = get_post( $post_id );


### PR DESCRIPTION
Modified parse_menu_icon() to preserve original icon_dashicons value
Added support for multiple icon types (dashicons, font_awesome, svg, custom)
Updated remove_menu_keys() to keep icon_dashicons in final output
Fixed issue where icon_dashicons was lost during parsing process
Resolves: Mb Settings Page: The Custom Icon is NOT Updated