### PR TITLE
Add CRUD abilities for field groups and fields

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -16,6 +16,7 @@ new Register();
 new RestApi\Generator();
 new RestApi\Save();
 new RestApi\ThemeCode\ThemeCode();
+new Abilities\FieldGroupAbilities();
 
 $fields_api = new RestApi\Fields( new Registry() );
 Helpers\FieldKeys::init( $fields_api );

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -16,7 +16,7 @@ new Register();
 new RestApi\Generator();
 new RestApi\Save();
 new RestApi\ThemeCode\ThemeCode();
-new Abilities\FieldGroupAbilities();
+new Abilities();
 
 $fields_api = new RestApi\Fields( new Registry() );
 Helpers\FieldKeys::init( $fields_api );

--- a/src/Abilities.php
+++ b/src/Abilities.php
@@ -1,5 +1,5 @@
 <?php
-namespace MBB\Abilities;
+namespace MBB;
 
 use MBB\RestApi\Save;
 use MBB\JsonService;
@@ -9,7 +9,7 @@ use MBBParser\Unparsers\Field as FieldUnparser;
 use WP_REST_Request;
 use WP_Error;
 
-class FieldGroupAbilities {
+class Abilities {
 	private const CATEGORY = 'meta-box';
 
 	public function __construct() {

--- a/src/Abilities.php
+++ b/src/Abilities.php
@@ -674,17 +674,21 @@ class Abilities {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
-		$unparsed   = $this->unparse_input( $input );
-		$title      = $unparsed['title'] ?: $post->post_title;
-		$slug       = $unparsed['slug'] ?: $post->post_name;
-		$has_status = array_key_exists( 'status', $input );
-		$status     = $unparsed['status'] ?? null;
-
 		$existing_fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$existing_settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		$fields   = $this->merge_fields( $existing_fields, $unparsed['fields'] );
-		$settings = $this->merge_settings( $existing_settings, $unparsed['settings'] );
+		$title      = empty( $input['title'] ) ? $post->post_title : $input['title'];
+		$slug       = empty( $input['slug'] ) ? $post->post_name : $input['slug'];
+		$has_status = array_key_exists( 'status', $input );
+		$status     = $input['status'] ?? null;
+
+		$unparsed = $this->unparse_input( $input );
+		$fields   = array_key_exists( 'fields', $input )
+			? $this->merge_fields( $existing_fields, $unparsed['fields'] )
+			: $existing_fields;
+		$settings = array_key_exists( 'settings', $input )
+			? $this->merge_settings( $existing_settings, $unparsed['settings'] )
+			: $existing_settings;
 
 		$result = $this->save_field_group( $post_id, $title, $slug, $fields, $settings );
 

--- a/src/Abilities.php
+++ b/src/Abilities.php
@@ -803,18 +803,20 @@ class Abilities {
 
 		$field_data = $this->unparse_field( $input['field'] );
 		$field_id   = $input['field_id'];
+		if ( empty( $input['field']['id'] ) ) {
+			$field_data['id'] = $field_id;
+		}
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		$new_id      = empty( $field_data['id'] ) ? $field_id : $field_data['id'];
 		$found_index = $this->find_field_index( $fields, $field_id );
 
 		if ( $found_index === -1 ) {
 			return $this->error( __( 'Field not found. Use create field instead.', 'meta-box-builder' ) );
 		}
 
-		// Check if renaming to an existing field ID.
+		$new_id = $field_data['id'];
 		if ( $new_id !== $field_id ) {
 			$collision_index = $this->find_field_index( $fields, $new_id );
 			if ( $collision_index !== -1 && $collision_index !== $found_index ) {

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -1,0 +1,863 @@
+<?php
+namespace MBB\Abilities;
+
+use MBB\RestApi\Save;
+use MBB\JsonService;
+use MBB\LocalJson;
+use WP_REST_Request;
+use WP_Error;
+
+class FieldGroupAbilities {
+	private const CATEGORY = 'meta-box';
+
+	public function __construct() {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+		add_action( 'wp_abilities_api_categories_init', [ $this, 'register_category' ] );
+		add_action( 'wp_abilities_api_init', [ $this, 'register_abilities' ] );
+	}
+
+	public function register_category(): void {
+		if ( wp_has_ability_category( self::CATEGORY ) ) {
+			return;
+		}
+
+		wp_register_ability_category( self::CATEGORY, [
+			'label' => __( 'Meta Box', 'meta-box-builder' ),
+		] );
+	}
+
+	public function register_abilities(): void {
+		$this->register_list_field_groups();
+		$this->register_get_field_group();
+		$this->register_create_field_group();
+		$this->register_update_field_group();
+		$this->register_delete_field_group();
+		$this->register_list_fields();
+		$this->register_get_field();
+		$this->register_create_field();
+		$this->register_update_field();
+		$this->register_delete_field();
+	}
+
+	private function register_list_field_groups(): void {
+		wp_register_ability( 'meta-box/list-field-groups', [
+			'label'               => __( 'List field groups', 'meta-box-builder' ),
+			'description'         => __( 'List all custom field groups stored in the database.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'search'   => [
+						'type'        => 'string',
+						'description' => __( 'Search field group titles.', 'meta-box-builder' ),
+					],
+					'status'   => [
+						'type'        => 'string',
+						'description' => __( 'Post status to filter by.', 'meta-box-builder' ),
+						'enum'        => [ 'publish', 'draft', 'pending', 'trash', 'any' ],
+						'default'     => 'publish',
+					],
+					'per_page' => [
+						'type'    => 'integer',
+						'default' => 20,
+					],
+					'page'     => [
+						'type'    => 'integer',
+						'default' => 1,
+					],
+				],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'field_groups' => [
+						'type'  => 'array',
+						'items' => [
+							'type'       => 'object',
+							'properties' => [
+								'id'          => [ 'type' => 'integer' ],
+								'title'       => [ 'type' => 'string' ],
+								'slug'        => [ 'type' => 'string' ],
+								'status'      => [ 'type' => 'string' ],
+								'field_count' => [ 'type' => 'integer' ],
+								'created_at'  => [ 'type' => 'string' ],
+								'modified_at' => [ 'type' => 'string' ],
+							],
+						],
+					],
+					'total'        => [ 'type' => 'integer' ],
+					'total_pages'  => [ 'type' => 'integer' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'list_field_groups' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_get_field_group(): void {
+		wp_register_ability( 'meta-box/get-field-group', [
+			'label'               => __( 'Get field group', 'meta-box-builder' ),
+			'description'         => __( 'Get a field group with all its fields and settings.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'id' => [
+						'type'        => 'integer',
+						'description' => __( 'The field group post ID.', 'meta-box-builder' ),
+					],
+				],
+				'required'   => [ 'id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'id'          => [ 'type' => 'integer' ],
+					'title'       => [ 'type' => 'string' ],
+					'slug'        => [ 'type' => 'string' ],
+					'status'      => [ 'type' => 'string' ],
+					'fields'      => [
+						'type'  => 'array',
+						'items' => [ 'type' => 'object' ],
+					],
+					'settings'    => [ 'type' => 'object' ],
+					'created_at'  => [ 'type' => 'string' ],
+					'modified_at' => [ 'type' => 'string' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'get_field_group' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_create_field_group(): void {
+		wp_register_ability( 'meta-box/create-field-group', [
+			'label'               => __( 'Create field group', 'meta-box-builder' ),
+			'description'         => __( 'Create a new field group.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'title'    => [
+						'type'        => 'string',
+						'description' => __( 'Field group title.', 'meta-box-builder' ),
+					],
+					'slug'     => [
+						'type'        => 'string',
+						'description' => __( 'Field group slug.', 'meta-box-builder' ),
+					],
+					'status'   => [
+						'type'        => 'string',
+						'description' => __( 'Post status.', 'meta-box-builder' ),
+						'enum'        => [ 'publish', 'draft' ],
+					],
+					'fields'   => [
+						'type'  => 'array',
+						'items' => [ 'type' => 'object' ],
+					],
+					'settings' => [
+						'type' => 'object',
+					],
+				],
+				'required'   => [ 'title' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+					'id'      => [ 'type' => 'integer' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'create_field_group' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_update_field_group(): void {
+		wp_register_ability( 'meta-box/update-field-group', [
+			'label'               => __( 'Update field group', 'meta-box-builder' ),
+			'description'         => __( 'Update an existing field group.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'id'       => [
+						'type'        => 'integer',
+						'description' => __( 'The field group post ID.', 'meta-box-builder' ),
+					],
+					'title'    => [
+						'type'        => 'string',
+						'description' => __( 'Field group title.', 'meta-box-builder' ),
+					],
+					'slug'     => [
+						'type'        => 'string',
+						'description' => __( 'Field group slug.', 'meta-box-builder' ),
+					],
+					'status'   => [
+						'type'        => 'string',
+						'description' => __( 'Post status.', 'meta-box-builder' ),
+						'enum'        => [ 'publish', 'draft' ],
+					],
+					'fields'   => [
+						'type'  => 'array',
+						'items' => [ 'type' => 'object' ],
+					],
+					'settings' => [
+						'type' => 'object',
+					],
+				],
+				'required'   => [ 'id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+					'id'      => [ 'type' => 'integer' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'update_field_group' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_delete_field_group(): void {
+		wp_register_ability( 'meta-box/delete-field-group', [
+			'label'               => __( 'Delete field group', 'meta-box-builder' ),
+			'description'         => __( 'Delete a field group. Supports trashing or permanent deletion.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'id'    => [
+						'type' => 'integer',
+					],
+					'force' => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+				],
+				'required'   => [ 'id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'delete_field_group' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_list_fields(): void {
+		wp_register_ability( 'meta-box/list-fields', [
+			'label'               => __( 'List fields', 'meta-box-builder' ),
+			'description'         => __( 'List all fields within a specific field group.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'field_group_id' => [
+						'type' => 'integer',
+					],
+				],
+				'required'   => [ 'field_group_id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'fields'   => [
+						'type'  => 'array',
+						'items' => [ 'type' => 'object' ],
+					],
+					'settings' => [ 'type' => 'object' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'list_fields' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_get_field(): void {
+		wp_register_ability( 'meta-box/get-field', [
+			'label'               => __( 'Get field', 'meta-box-builder' ),
+			'description'         => __( 'Get a single field definition from a field group by its field ID.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'field_group_id' => [
+						'type' => 'integer',
+					],
+					'field_id'       => [
+						'type'        => 'string',
+						'description' => __( 'The field ID (without prefix).', 'meta-box-builder' ),
+					],
+				],
+				'required'   => [ 'field_group_id', 'field_id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'field' => [ 'type' => 'object' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'get_field' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_create_field(): void {
+		wp_register_ability( 'meta-box/create-field', [
+			'label'               => __( 'Create field', 'meta-box-builder' ),
+			'description'         => __( 'Add a new field to a field group.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'field_group_id' => [
+						'type' => 'integer',
+					],
+					'field'          => [
+						'type'        => 'object',
+						'description' => __( 'The field definition. Must include id, type, and name.', 'meta-box-builder' ),
+						'properties'  => [
+							'id'   => [ 'type' => 'string' ],
+							'type' => [ 'type' => 'string' ],
+							'name' => [ 'type' => 'string' ],
+						],
+					],
+				],
+				'required'   => [ 'field_group_id', 'field' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'create_field' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_update_field(): void {
+		wp_register_ability( 'meta-box/update-field', [
+			'label'               => __( 'Update field', 'meta-box-builder' ),
+			'description'         => __( 'Update an existing field in a field group.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'field_group_id' => [
+						'type' => 'integer',
+					],
+					'field'          => [
+						'type'        => 'object',
+						'description' => __( 'The field definition. Must include id.', 'meta-box-builder' ),
+						'properties'  => [
+							'id'   => [ 'type' => 'string' ],
+							'type' => [ 'type' => 'string' ],
+							'name' => [ 'type' => 'string' ],
+						],
+					],
+				],
+				'required'   => [ 'field_group_id', 'field' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'update_field' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	private function register_delete_field(): void {
+		wp_register_ability( 'meta-box/delete-field', [
+			'label'               => __( 'Delete field', 'meta-box-builder' ),
+			'description'         => __( 'Remove a field from a field group by its field ID.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'field_group_id' => [
+						'type' => 'integer',
+					],
+					'field_id'       => [
+						'type' => 'string',
+					],
+				],
+				'required'   => [ 'field_group_id', 'field_id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'delete_field' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
+	/**
+	 * Execute callbacks.
+	 */
+	public function list_field_groups( array $input ): array {
+		$search   = $input['search'] ?? '';
+		$status   = $input['status'] ?? 'publish';
+		$per_page = $input['per_page'] ?? 20;
+		$page     = $input['page'] ?? 1;
+
+		$args = [
+			'post_type'              => 'meta-box',
+			'post_status'            => $status,
+			'posts_per_page'         => $per_page,
+			'paged'                  => $page,
+			'no_found_rows'          => false,
+			'update_post_term_cache' => false,
+		];
+
+		if ( $search ) {
+			$args['s'] = $search;
+		}
+
+		$query  = new \WP_Query( $args );
+		$groups = [];
+
+		foreach ( $query->posts as $post ) {
+			if ( ! $this->is_database_only( $post ) ) {
+				continue;
+			}
+			$groups[] = $this->build_field_group_summary( $post );
+		}
+
+		return [
+			'field_groups' => $groups,
+			'total'        => $query->found_posts,
+			'total_pages'  => $query->max_num_pages,
+		];
+	}
+
+	public function get_field_group( array $input ): array {
+		$post = get_post( $input['id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
+		}
+
+		return $this->build_field_group_response( $post );
+	}
+
+	public function create_field_group( array $input ): array {
+		$title    = $input['title'];
+		$slug     = $input['slug'] ?? '';
+		$fields   = $input['fields'] ?? [];
+		$settings = $input['settings'] ?? [];
+
+		$post_id = wp_insert_post( [
+			'post_type'   => 'meta-box',
+			'post_title'  => $title,
+			'post_name'   => $slug ? $slug : sanitize_title( $title ),
+			'post_status' => 'publish',
+		] );
+
+		if ( is_wp_error( $post_id ) ) {
+			return [
+				'success' => false,
+				'message' => $post_id->get_error_message(),
+				'id'      => 0,
+			];
+		}
+
+		$request = new WP_REST_Request( 'POST', '/mbb/save' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'post_title', $title );
+		$request->set_param( 'post_name', $slug );
+		$request->set_param( 'fields', $fields );
+		$request->set_param( 'settings', $settings );
+
+		$save   = new Save();
+		$result = $save->save( $request );
+
+		if ( ! empty( $input['status'] ) && ! empty( $result['success'] ) ) {
+			wp_update_post( [
+				'ID'          => $post_id,
+				'post_status' => $input['status'],
+			] );
+		}
+
+		return array_merge( $result, [ 'id' => $post_id ] );
+	}
+
+	public function update_field_group( array $input ): array {
+		$post_id = $input['id'];
+		$post    = get_post( $post_id );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group not found.', 'meta-box-builder' ),
+			];
+		}
+
+		$title    = $input['title'] ?? $post->post_title;
+		$slug     = $input['slug'] ?? $post->post_name;
+		$fields   = $input['fields'] ?? [];
+		$settings = $input['settings'] ?? [];
+
+		$request = new WP_REST_Request( 'POST', '/mbb/save' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'post_title', $title );
+		$request->set_param( 'post_name', $slug );
+		$request->set_param( 'fields', $fields );
+		$request->set_param( 'settings', $settings );
+
+		$save   = new Save();
+		$result = $save->save( $request );
+
+		if ( ! empty( $input['status'] ) && ! empty( $result['success'] ) ) {
+			wp_update_post( [
+				'ID'          => $post_id,
+				'post_status' => $input['status'],
+			] );
+		}
+
+		return array_merge( $result, [ 'id' => $post_id ] );
+	}
+
+	public function delete_field_group( array $input ): array {
+		$post = get_post( $input['id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group not found.', 'meta-box-builder' ),
+			];
+		}
+
+		$force  = $input['force'] ?? false;
+		$result = wp_delete_post( $post->ID, $force );
+
+		if ( ! $result ) {
+			return [
+				'success' => false,
+				'message' => __( 'Failed to delete field group.', 'meta-box-builder' ),
+			];
+		}
+
+		return [
+			'success' => true,
+			'message' => $force
+				? __( 'Field group permanently deleted.', 'meta-box-builder' )
+				: __( 'Field group moved to trash.', 'meta-box-builder' ),
+		];
+	}
+
+	public function list_fields( array $input ): array {
+		$post = get_post( $input['field_group_id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
+		}
+
+		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
+
+		return [
+			'fields'   => array_values( $fields ),
+			'settings' => $settings,
+		];
+	}
+
+	public function get_field( array $input ): array {
+		$post = get_post( $input['field_group_id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
+		}
+
+		$fields = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		foreach ( $fields as $field ) {
+			if ( ( $field['id'] ?? '' ) === $input['field_id'] ) {
+				return [ 'field' => $field ];
+			}
+		}
+
+		return new WP_Error( 'not_found', __( 'Field not found.', 'meta-box-builder' ) );
+	}
+
+	public function create_field( array $input ): array {
+		$post = get_post( $input['field_group_id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group not found.', 'meta-box-builder' ),
+			];
+		}
+
+		$field_data = $input['field'];
+		if ( empty( $field_data['id'] ) || empty( $field_data['type'] ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field must have id and type.', 'meta-box-builder' ),
+			];
+		}
+
+		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
+
+		foreach ( $fields as $f ) {
+			if ( ( $f['id'] ?? '' ) === $field_data['id'] ) {
+				return [
+					'success' => false,
+					'message' => __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ),
+				];
+			}
+		}
+
+		$fields[] = $field_data;
+		Save::parse( $post, $fields, $settings );
+
+		return [
+			'success' => true,
+			'message' => __( 'Field added successfully.', 'meta-box-builder' ),
+		];
+	}
+
+	public function update_field( array $input ): array {
+		$post = get_post( $input['field_group_id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group not found.', 'meta-box-builder' ),
+			];
+		}
+
+		$field_data = $input['field'];
+		if ( empty( $field_data['id'] ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field must have an id.', 'meta-box-builder' ),
+			];
+		}
+
+		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
+
+		$found = false;
+		foreach ( $fields as &$f ) {
+			if ( ( $f['id'] ?? '' ) === $field_data['id'] ) {
+				$f     = array_merge( $f, $field_data );
+				$found = true;
+				break;
+			}
+		}
+		unset( $f );
+
+		if ( ! $found ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field not found. Use create field instead.', 'meta-box-builder' ),
+			];
+		}
+
+		Save::parse( $post, $fields, $settings );
+
+		return [
+			'success' => true,
+			'message' => __( 'Field updated successfully.', 'meta-box-builder' ),
+		];
+	}
+
+	public function delete_field( array $input ): array {
+		$post = get_post( $input['field_group_id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group not found.', 'meta-box-builder' ),
+			];
+		}
+
+		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
+
+		$original_count = count( $fields );
+		$fields         = array_values( array_filter( $fields, function ( $f ) use ( $input ) {
+			return ( $f['id'] ?? '' ) !== $input['field_id'];
+		} ) );
+
+		if ( count( $fields ) === $original_count ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field not found.', 'meta-box-builder' ),
+			];
+		}
+
+		Save::parse( $post, $fields, $settings );
+
+		return [
+			'success' => true,
+			'message' => __( 'Field deleted successfully.', 'meta-box-builder' ),
+		];
+	}
+
+	/**
+	 * Helpers.
+	 */
+	public function permission_callback(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	private function is_database_only( \WP_Post $post ): bool {
+		if ( ! LocalJson::is_enabled() ) {
+			return true;
+		}
+
+		$json = JsonService::get_json( [
+			'id'        => $post->post_name,
+			'post_type' => $post->post_type,
+		] );
+
+		return empty( $json );
+	}
+
+	private function build_field_group_summary( \WP_Post $post ): array {
+		$fields = get_post_meta( $post->ID, 'fields', true ) ?: [];
+
+		return [
+			'id'          => $post->ID,
+			'title'       => $post->post_title,
+			'slug'        => $post->post_name,
+			'status'      => $post->post_status,
+			'field_count' => count( $fields ),
+			'created_at'  => $post->post_date,
+			'modified_at' => $post->post_modified,
+		];
+	}
+
+	private function build_field_group_response( \WP_Post $post ): array {
+		$summary = $this->build_field_group_summary( $post );
+
+		return array_merge( $summary, [
+			'fields'   => array_values( get_post_meta( $post->ID, 'fields', true ) ?: [] ),
+			'settings' => get_post_meta( $post->ID, 'settings', true ) ?: [],
+		] );
+	}
+}

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -449,7 +449,7 @@ class FieldGroupAbilities {
 	private function register_update_field(): void {
 		wp_register_ability( 'meta-box/update-field', [
 			'label'               => __( 'Update field', 'meta-box-builder' ),
-			'description'         => __( 'Update an existing field in a field group.', 'meta-box-builder' ),
+			'description'         => __( 'Update an existing field in a field group. Use field_id to identify the field to update. The field.id in the field object can be changed to rename the field.', 'meta-box-builder' ),
 			'category'            => self::CATEGORY,
 			'input_schema'        => [
 				'type'       => 'object',
@@ -457,9 +457,13 @@ class FieldGroupAbilities {
 					'field_group_id' => [
 						'type' => 'integer',
 					],
+					'field_id'       => [
+						'type'        => 'string',
+						'description' => __( 'The current field ID to identify which field to update.', 'meta-box-builder' ),
+					],
 					'field'          => [
 						'type'                 => 'object',
-						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. options, std, placeholder, required, desc, clone, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'description'          => __( 'Field definition. Accepts all Meta Box field properties. The id property can be changed to rename the field. See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
 						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
@@ -468,7 +472,7 @@ class FieldGroupAbilities {
 						'additionalProperties' => true,
 					],
 				],
-				'required'   => [ 'field_group_id', 'field' ],
+				'required'   => [ 'field_group_id', 'field_id', 'field' ],
 			],
 			'output_schema'       => [
 				'type'       => 'object',
@@ -769,19 +773,14 @@ class FieldGroupAbilities {
 		}
 
 		$field_data = $this->unparse_field( $input['field'] );
-		if ( empty( $field_data['id'] ) ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field must have an id.', 'meta-box-builder' ),
-			];
-		}
+		$field_id   = $input['field_id'];
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
 		$found = false;
 		foreach ( $fields as &$f ) {
-			if ( ( $f['id'] ?? '' ) === $field_data['id'] ) {
+			if ( ( $f['id'] ?? '' ) === $field_id ) {
 				$f     = array_merge( $f, $field_data );
 				$found = true;
 				break;

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -410,11 +410,10 @@ class FieldGroupAbilities {
 					],
 					'field'          => [
 						'type'                 => 'object',
-						'description'          => __( 'Field definition. Must include id, type, name. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
 						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
-							'name' => [ 'type' => 'string' ],
 						],
 						'additionalProperties' => true,
 					],
@@ -457,11 +456,10 @@ class FieldGroupAbilities {
 					],
 					'field'          => [
 						'type'                 => 'object',
-						'description'          => __( 'Field definition. Must include id. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
 						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
-							'name' => [ 'type' => 'string' ],
 						],
 						'additionalProperties' => true,
 					],

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -784,7 +784,8 @@ class FieldGroupAbilities {
 			return $this->error( __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ) );
 		}
 
-		$fields[] = $field_data;
+		$field_data = $this->ensure_unique_field_id( $field_data, $fields );
+		$fields[]   = $field_data;
 		Save::parse( $post, $fields, $settings );
 
 		return $this->success( __( 'Field added successfully.', 'meta-box-builder' ) );
@@ -802,7 +803,7 @@ class FieldGroupAbilities {
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		$new_id = $field_data['id'] ?? $field_id;
+		$new_id      = empty( $field_data['id'] ) ? $field_id : $field_data['id'];
 		$found_index = $this->find_field_index( $fields, $field_id );
 
 		if ( $found_index === -1 ) {
@@ -822,6 +823,7 @@ class FieldGroupAbilities {
 		}
 
 		$fields[ $found_index ] = $this->merge_settings( $fields[ $found_index ], $field_data );
+		$fields[ $found_index ] = $this->ensure_unique_field_id( $fields[ $found_index ], $fields, $found_index );
 		if ( ( $field_data['type'] ?? '' ) === 'group' && isset( $field_data['fields'] ) ) {
 			$existing_sub                     = $fields[ $found_index ]['fields'] ?? [];
 			$fields[ $found_index ]['fields'] = $this->merge_fields( $existing_sub, $field_data['fields'] );
@@ -926,6 +928,24 @@ class FieldGroupAbilities {
 		}
 
 		return -1;
+	}
+
+	private function ensure_unique_field_id( array $field_data, array $existing_fields, ?int $exclude_index = null ): array {
+		$existing_ids = [];
+		foreach ( $existing_fields as $index => $field ) {
+			if ( $exclude_index !== null && $index === $exclude_index ) {
+				continue;
+			}
+			if ( ! empty( $field['_id'] ) ) {
+				$existing_ids[] = $field['_id'];
+			}
+		}
+
+		while ( in_array( $field_data['_id'] ?? '', $existing_ids, true ) ) {
+			$field_data['_id'] = ( $field_data['type'] ?? 'field' ) . '_' . uniqid();
+		}
+
+		return $field_data;
 	}
 
 	private function save_field_group( int $post_id, string $title, string $slug, array $fields, array $settings ): array {

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -691,7 +691,7 @@ class FieldGroupAbilities {
 		$unparsed   = $this->unparse_input( $input );
 		$title      = $unparsed['title'] ?: $post->post_title;
 		$slug       = $unparsed['slug'] ?: $post->post_name;
-		$has_status = array_key_exists( 'status', $input ) || array_key_exists( 'status', $unparsed );
+		$has_status = array_key_exists( 'status', $input );
 		$status     = $unparsed['status'] ?? null;
 
 		$existing_fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
@@ -790,7 +790,8 @@ class FieldGroupAbilities {
 
 		$fields = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		foreach ( $fields as $field ) {
-			if ( ( $field['id'] ?? '' ) === $input['field_id'] ) {
+			$id = $field['id'] ?? $field['_id'] ?? '';
+			if ( $id === $input['field_id'] ) {
 				return [ 'field' => $field ];
 			}
 		}
@@ -907,7 +908,8 @@ class FieldGroupAbilities {
 
 		$original_count = count( $fields );
 		$fields         = array_values( array_filter( $fields, function ( $f ) use ( $input ) {
-			return ( $f['id'] ?? '' ) !== $input['field_id'];
+			$id = $f['id'] ?? $f['_id'] ?? '';
+			return $id !== $input['field_id'];
 		} ) );
 
 		if ( count( $fields ) === $original_count ) {
@@ -940,7 +942,8 @@ class FieldGroupAbilities {
 		$field_to_move = null;
 		$field_index   = -1;
 		foreach ( $fields as $index => $f ) {
-			if ( ( $f['id'] ?? '' ) === $input['field_id'] ) {
+			$id = $f['id'] ?? $f['_id'] ?? '';
+			if ( $id === $input['field_id'] ) {
 				$field_to_move = $f;
 				$field_index   = $index;
 				break;
@@ -966,7 +969,8 @@ class FieldGroupAbilities {
 
 		if ( $target_id !== null ) {
 			foreach ( $fields as $index => $f ) {
-				if ( ( $f['id'] ?? '' ) === $target_id ) {
+				$id = $f['id'] ?? $f['_id'] ?? '';
+				if ( $id === $target_id ) {
 					$position = isset( $input['before'] ) ? $index : $index + 1;
 					break;
 				}

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -31,20 +31,20 @@ class FieldGroupAbilities {
 	}
 
 	public function register_abilities(): void {
-		$this->register_list_field_groups();
-		$this->register_get_field_group();
-		$this->register_create_field_group();
-		$this->register_update_field_group();
-		$this->register_delete_field_group();
-		$this->register_list_fields();
-		$this->register_get_field();
-		$this->register_create_field();
-		$this->register_update_field();
-		$this->register_delete_field();
-		$this->register_move_field();
+		$this->register_list_field_groups_ability();
+		$this->register_get_field_group_ability();
+		$this->register_create_field_group_ability();
+		$this->register_update_field_group_ability();
+		$this->register_delete_field_group_ability();
+		$this->register_list_fields_ability();
+		$this->register_get_field_ability();
+		$this->register_create_field_ability();
+		$this->register_update_field_ability();
+		$this->register_delete_field_ability();
+		$this->register_move_field_ability();
 	}
 
-	private function register_list_field_groups(): void {
+	private function register_list_field_groups_ability(): void {
 		wp_register_ability( 'meta-box/list-field-groups', [
 			'label'               => __( 'List field groups', 'meta-box-builder' ),
 			'description'         => __( 'List all custom field groups stored in the database.', 'meta-box-builder' ),
@@ -110,7 +110,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_get_field_group(): void {
+	private function register_get_field_group_ability(): void {
 		wp_register_ability( 'meta-box/get-field-group', [
 			'label'               => __( 'Get field group', 'meta-box-builder' ),
 			'description'         => __( 'Get a field group with all its fields and settings.', 'meta-box-builder' ),
@@ -157,7 +157,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_create_field_group(): void {
+	private function register_create_field_group_ability(): void {
 		wp_register_ability( 'meta-box/create-field-group', [
 			'label'               => __( 'Create field group', 'meta-box-builder' ),
 			'description'         => __( 'Create a new field group.', 'meta-box-builder' ),
@@ -216,7 +216,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_update_field_group(): void {
+	private function register_update_field_group_ability(): void {
 		wp_register_ability( 'meta-box/update-field-group', [
 			'label'               => __( 'Update field group', 'meta-box-builder' ),
 			'description'         => __( 'Update an existing field group.', 'meta-box-builder' ),
@@ -279,7 +279,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_delete_field_group(): void {
+	private function register_delete_field_group_ability(): void {
 		wp_register_ability( 'meta-box/delete-field-group', [
 			'label'               => __( 'Delete field group', 'meta-box-builder' ),
 			'description'         => __( 'Delete a field group. Supports trashing or permanent deletion.', 'meta-box-builder' ),
@@ -320,7 +320,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_list_fields(): void {
+	private function register_list_fields_ability(): void {
 		wp_register_ability( 'meta-box/list-fields', [
 			'label'               => __( 'List fields', 'meta-box-builder' ),
 			'description'         => __( 'List all fields within a specific field group.', 'meta-box-builder' ),
@@ -360,7 +360,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_get_field(): void {
+	private function register_get_field_ability(): void {
 		wp_register_ability( 'meta-box/get-field', [
 			'label'               => __( 'Get field', 'meta-box-builder' ),
 			'description'         => __( 'Get a single field definition from a field group by its field ID.', 'meta-box-builder' ),
@@ -400,7 +400,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_create_field(): void {
+	private function register_create_field_ability(): void {
 		wp_register_ability( 'meta-box/create-field', [
 			'label'               => __( 'Create field', 'meta-box-builder' ),
 			'description'         => __( 'Add a new field to a field group.', 'meta-box-builder' ),
@@ -447,7 +447,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_update_field(): void {
+	private function register_update_field_ability(): void {
 		wp_register_ability( 'meta-box/update-field', [
 			'label'               => __( 'Update field', 'meta-box-builder' ),
 			'description'         => __( 'Update an existing field in a field group. Use field_id to identify the field to update. The field.id in the field object can be changed to rename the field.', 'meta-box-builder' ),
@@ -498,7 +498,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_delete_field(): void {
+	private function register_delete_field_ability(): void {
 		wp_register_ability( 'meta-box/delete-field', [
 			'label'               => __( 'Delete field', 'meta-box-builder' ),
 			'description'         => __( 'Remove a field from a field group by its field ID.', 'meta-box-builder' ),
@@ -538,7 +538,7 @@ class FieldGroupAbilities {
 		] );
 	}
 
-	private function register_move_field(): void {
+	private function register_move_field_ability(): void {
 		wp_register_ability( 'meta-box/move-field', [
 			'label'               => __( 'Move field', 'meta-box-builder' ),
 			'description'         => __( 'Move a field to a new position within a field group. Specify before or after a reference field ID.', 'meta-box-builder' ),
@@ -873,31 +873,31 @@ class FieldGroupAbilities {
 			];
 		}
 
+		// Check if update field id to an existing field id.
 		if ( $new_id !== $field_id ) {
 			foreach ( $fields as $index => $f ) {
 				if ( $index === $found_index ) {
 					continue;
 				}
 				$existing_id = $f['id'] ?? $f['_id'] ?? '';
-				if ( $existing_id === $new_id ) {
-					return [
-						'success' => false,
-						'message' => sprintf(
-							/* translators: %s: The new field ID. */
-							__( 'Another field with ID %s already exists.', 'meta-box-builder' ),
-							$new_id
-						),
-					];
+				if ( $existing_id !== $new_id ) {
+					continue;
 				}
+				return [
+					'success' => false,
+					'message' => sprintf(
+						/* translators: %s: The new field ID. */
+						__( 'Another field with ID %s already exists.', 'meta-box-builder' ),
+						$new_id
+					),
+				];
 			}
 		}
 
+		$fields[ $found_index ] = $this->merge_settings( $fields[ $found_index ], $field_data );
 		if ( ( $field_data['type'] ?? '' ) === 'group' && isset( $field_data['fields'] ) ) {
 			$existing_sub                     = $fields[ $found_index ]['fields'] ?? [];
-			$fields[ $found_index ]           = $this->merge_settings( $fields[ $found_index ], $field_data );
 			$fields[ $found_index ]['fields'] = $this->merge_fields( $existing_sub, $field_data['fields'] );
-		} else {
-			$fields[ $found_index ] = $this->merge_settings( $fields[ $found_index ], $field_data );
 		}
 
 		Save::parse( $post, $fields, $settings );

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -4,6 +4,8 @@ namespace MBB\Abilities;
 use MBB\RestApi\Save;
 use MBB\JsonService;
 use MBB\LocalJson;
+use MBBParser\Unparsers\MetaBox;
+use MBBParser\Unparsers\Field as FieldUnparser;
 use WP_REST_Request;
 use WP_Error;
 
@@ -410,10 +412,11 @@ class FieldGroupAbilities {
 					],
 					'field'          => [
 						'type'                 => 'object',
-						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. options, std, placeholder, required, desc, clone, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
 						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
+							'name' => [ 'type' => 'string' ],
 						],
 						'additionalProperties' => true,
 					],
@@ -456,10 +459,11 @@ class FieldGroupAbilities {
 					],
 					'field'          => [
 						'type'                 => 'object',
-						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'description'          => __( 'Field definition. Must include id, type. Accepts all Meta Box field properties (e.g. options, std, placeholder, required, desc, clone, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
 						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
+							'name' => [ 'type' => 'string' ],
 						],
 						'additionalProperties' => true,
 					],
@@ -578,10 +582,11 @@ class FieldGroupAbilities {
 	}
 
 	public function create_field_group( array $input ): array {
-		$title    = $input['title'];
-		$slug     = $input['slug'] ?? '';
-		$fields   = $input['fields'] ?? [];
-		$settings = $input['settings'] ?? [];
+		$unparsed = $this->unparse_input( $input );
+		$title    = $unparsed['title'];
+		$slug     = $unparsed['slug'];
+		$fields   = $unparsed['fields'];
+		$settings = $unparsed['settings'];
 
 		$post_id = wp_insert_post( [
 			'post_type'   => 'meta-box',
@@ -608,10 +613,10 @@ class FieldGroupAbilities {
 		$save   = new Save();
 		$result = $save->save( $request );
 
-		if ( ! empty( $input['status'] ) && ! empty( $result['success'] ) ) {
+		if ( ! empty( $unparsed['status'] ) && ! empty( $result['success'] ) && $unparsed['status'] !== 'publish' ) {
 			wp_update_post( [
 				'ID'          => $post_id,
-				'post_status' => $input['status'],
+				'post_status' => $unparsed['status'],
 			] );
 		}
 
@@ -628,10 +633,15 @@ class FieldGroupAbilities {
 			];
 		}
 
-		$title    = $input['title'] ?? $post->post_title;
-		$slug     = $input['slug'] ?? $post->post_name;
-		$fields   = $input['fields'] ?? [];
-		$settings = $input['settings'] ?? [];
+		$unparsed = $this->unparse_input( $input );
+		$title    = $unparsed['title'] ?: $post->post_title;
+		$slug     = $unparsed['slug'] ?: $post->post_name;
+
+		$existing_fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$existing_settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
+
+		$fields   = $this->merge_fields( $existing_fields, $unparsed['fields'] );
+		$settings = $this->merge_settings( $existing_settings, $unparsed['settings'] );
 
 		$request = new WP_REST_Request( 'POST', '/mbb/save' );
 		$request->set_param( 'post_id', $post_id );
@@ -643,10 +653,10 @@ class FieldGroupAbilities {
 		$save   = new Save();
 		$result = $save->save( $request );
 
-		if ( ! empty( $input['status'] ) && ! empty( $result['success'] ) ) {
+		if ( ! empty( $unparsed['status'] ) && ! empty( $result['success'] ) && $unparsed['status'] !== 'publish' ) {
 			wp_update_post( [
 				'ID'          => $post_id,
-				'post_status' => $input['status'],
+				'post_status' => $unparsed['status'],
 			] );
 		}
 
@@ -720,7 +730,7 @@ class FieldGroupAbilities {
 			];
 		}
 
-		$field_data = $input['field'];
+		$field_data = $this->unparse_field( $input['field'] );
 		if ( empty( $field_data['id'] ) || empty( $field_data['type'] ) ) {
 			return [
 				'success' => false,
@@ -758,7 +768,7 @@ class FieldGroupAbilities {
 			];
 		}
 
-		$field_data = $input['field'];
+		$field_data = $this->unparse_field( $input['field'] );
 		if ( empty( $field_data['id'] ) ) {
 			return [
 				'success' => false,
@@ -867,5 +877,93 @@ class FieldGroupAbilities {
 			'fields'   => array_values( get_post_meta( $post->ID, 'fields', true ) ?: [] ),
 			'settings' => get_post_meta( $post->ID, 'settings', true ) ?: [],
 		] );
+	}
+
+	/**
+	 * Unparse input data from parsed format to builder format.
+	 *
+	 * Accepts input in the schema format (https://github.com/wpmetabox/schema/blob/main/field-group.json)
+	 * and converts it to the builder format used internally.
+	 */
+	private function unparse_input( array $input ): array {
+		$unparser = new MetaBox( $input );
+		$unparser->unparse();
+
+		$settings = $unparser->get_settings();
+
+		return [
+			'title'    => $settings['post_title'] ?? $input['title'] ?? '',
+			'slug'     => $settings['post_name'] ?? $input['slug'] ?? '',
+			'fields'   => $settings['fields'] ?? $input['fields'] ?? [],
+			'settings' => $settings['settings'] ?? $input['settings'] ?? [],
+			'status'   => $settings['post_status'] ?? $input['status'] ?? 'publish',
+		];
+	}
+
+	/**
+	 * Unparse a single field from parsed format to builder format.
+	 */
+	private function unparse_field( array $field ): array {
+		$unparser = new FieldUnparser( $field );
+		$unparser->unparse();
+
+		return $unparser->get_settings();
+	}
+
+	/**
+	 * Merge new settings into existing settings recursively.
+	 *
+	 * Existing keys not in the new settings are preserved.
+	 * Nested arrays are merged recursively.
+	 */
+	private function merge_settings( array $existing, array $new ): array {
+		foreach ( $new as $key => $value ) {
+			if ( is_array( $value ) && isset( $existing[ $key ] ) && is_array( $existing[ $key ] ) ) {
+				$existing[ $key ] = $this->merge_settings( $existing[ $key ], $value );
+			} else {
+				$existing[ $key ] = $value;
+			}
+		}
+
+		return $existing;
+	}
+
+	/**
+	 * Merge new fields into existing fields by ID.
+	 *
+	 * Existing fields not in the new list are preserved.
+	 * Fields with matching IDs are updated.
+	 * New fields are appended.
+	 */
+	private function merge_fields( array $existing, array $new ): array {
+		if ( empty( $new ) ) {
+			return $existing;
+		}
+
+		$new_by_id = [];
+		foreach ( $new as $field ) {
+			$id = $field['_id'] ?? $field['id'] ?? '';
+			if ( $id ) {
+				$new_by_id[ $id ] = $field;
+			}
+		}
+
+		$merged = [];
+		foreach ( $existing as $field ) {
+			$id = $field['_id'] ?? $field['id'] ?? '';
+			if ( isset( $new_by_id[ $id ] ) ) {
+				$merged[] = $new_by_id[ $id ];
+				unset( $new_by_id[ $id ] );
+			} else {
+				$merged[] = $field;
+			}
+		}
+
+		// Append remaining new fields.
+		foreach ( $new_by_id as $field ) {
+			$merged[] = $field;
+		}
+
+		return $merged;
 	}
 }

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -626,7 +626,13 @@ class FieldGroupAbilities {
 		];
 	}
 
-	public function get_field_group( array $input ): array {
+	/**
+	 * Get a field group with all its fields and settings.
+	 *
+	 * @param array{id: int} $input The input arguments.
+	 * @return array|WP_Error
+	 */
+	public function get_field_group( array $input ) {
 		$post = get_post( $input['id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
 			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
@@ -641,12 +647,13 @@ class FieldGroupAbilities {
 		$slug     = $unparsed['slug'];
 		$fields   = $unparsed['fields'];
 		$settings = $unparsed['settings'];
+		$status   = $unparsed['status'] ?? 'publish';
 
 		$post_id = wp_insert_post( [
 			'post_type'   => 'meta-box',
 			'post_title'  => $title,
 			'post_name'   => $slug ? $slug : sanitize_title( $title ),
-			'post_status' => 'publish',
+			'post_status' => $status,
 		] );
 
 		if ( is_wp_error( $post_id ) ) {
@@ -667,13 +674,6 @@ class FieldGroupAbilities {
 		$save   = new Save();
 		$result = $save->save( $request );
 
-		if ( ! empty( $unparsed['status'] ) && ! empty( $result['success'] ) && $unparsed['status'] !== 'publish' ) {
-			wp_update_post( [
-				'ID'          => $post_id,
-				'post_status' => $unparsed['status'],
-			] );
-		}
-
 		return array_merge( $result, [ 'id' => $post_id ] );
 	}
 
@@ -690,6 +690,7 @@ class FieldGroupAbilities {
 		$unparsed = $this->unparse_input( $input );
 		$title    = $unparsed['title'] ?: $post->post_title;
 		$slug     = $unparsed['slug'] ?: $post->post_name;
+		$status   = $unparsed['status'] ?? null;
 
 		$existing_fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$existing_settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
@@ -707,10 +708,10 @@ class FieldGroupAbilities {
 		$save   = new Save();
 		$result = $save->save( $request );
 
-		if ( ! empty( $unparsed['status'] ) && ! empty( $result['success'] ) && $unparsed['status'] !== 'publish' ) {
+		if ( ! empty( $result['success'] ) && $status !== null && $status !== $post->post_status ) {
 			wp_update_post( [
 				'ID'          => $post_id,
-				'post_status' => $unparsed['status'],
+				'post_status' => $status,
 			] );
 		}
 
@@ -744,7 +745,13 @@ class FieldGroupAbilities {
 		];
 	}
 
-	public function list_fields( array $input ): array {
+	/**
+	 * List all fields within a specific field group.
+	 *
+	 * @param array{field_group_id: int} $input The input arguments.
+	 * @return array|WP_Error
+	 */
+	public function list_fields( array $input ) {
 		$post = get_post( $input['field_group_id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
 			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
@@ -759,7 +766,13 @@ class FieldGroupAbilities {
 		];
 	}
 
-	public function get_field( array $input ): array {
+	/**
+	 * Get a single field definition from a field group by its field ID.
+	 *
+	 * @param array{field_group_id: int, field_id: string} $input The input arguments.
+	 * @return array|WP_Error
+	 */
+	public function get_field( array $input ) {
 		$post = get_post( $input['field_group_id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
 			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
@@ -807,6 +820,14 @@ class FieldGroupAbilities {
 		$fields[] = $field_data;
 		Save::parse( $post, $fields, $settings );
 
+		$updated = get_post( $post->ID );
+		if ( ! $updated ) {
+			return [
+				'success' => false,
+				'message' => __( 'Failed to save field.', 'meta-box-builder' ),
+			];
+		}
+
 		return [
 			'success' => true,
 			'message' => __( 'Field added successfully.', 'meta-box-builder' ),
@@ -847,6 +868,14 @@ class FieldGroupAbilities {
 
 		Save::parse( $post, $fields, $settings );
 
+		$updated = get_post( $post->ID );
+		if ( ! $updated ) {
+			return [
+				'success' => false,
+				'message' => __( 'Failed to save field.', 'meta-box-builder' ),
+			];
+		}
+
 		return [
 			'success' => true,
 			'message' => __( 'Field updated successfully.', 'meta-box-builder' ),
@@ -878,6 +907,14 @@ class FieldGroupAbilities {
 		}
 
 		Save::parse( $post, $fields, $settings );
+
+		$updated = get_post( $post->ID );
+		if ( ! $updated ) {
+			return [
+				'success' => false,
+				'message' => __( 'Failed to delete field.', 'meta-box-builder' ),
+			];
+		}
 
 		return [
 			'success' => true,
@@ -914,28 +951,59 @@ class FieldGroupAbilities {
 			];
 		}
 
-		// Remove the field from its current position.
-		array_splice( $fields, $field_index, 1 );
-
-		// Find the target position.
-		$target_id = $input['before'] ?? $input['after'] ?? '';
+		$target_id = $input['before'] ?? $input['after'] ?? null;
 		$position  = -1;
-		foreach ( $fields as $index => $f ) {
-			if ( ( $f['id'] ?? '' ) === $target_id ) {
-				$position = $input['before'] ?? '' ? $index : $index + 1;
-				break;
-			}
-		}
 
-		// If target not found or not specified, append to end.
-		if ( $position === -1 ) {
+		if ( $target_id !== null ) {
+			foreach ( $fields as $index => $f ) {
+				if ( ( $f['id'] ?? '' ) === $target_id ) {
+					$position = isset( $input['before'] ) ? $index : $index + 1;
+					break;
+				}
+			}
+
+			if ( $position === -1 ) {
+				return [
+					'success' => false,
+					'message' => sprintf(
+						/* translators: %s: The field ID to move before/after. */
+						__( 'Target field %s not found.', 'meta-box-builder' ),
+						$target_id
+					),
+				];
+			}
+		} else {
 			$position = count( $fields );
 		}
 
+		// Check if the field is already at the target position (no-op).
+		$current_index = $field_index;
+		$target_index  = $position;
+		if ( $target_index > $current_index ) {
+			--$target_index;
+		}
+		if ( $current_index === $target_index ) {
+			return [
+				'success' => true,
+				'message' => __( 'Field is already at the target position.', 'meta-box-builder' ),
+			];
+		}
+
+		// Remove the field from its current position.
+		array_splice( $fields, $field_index, 1 );
+
 		// Insert at the target position.
-		array_splice( $fields, $position, 0, [ $field_to_move ] );
+		array_splice( $fields, $target_index, 0, [ $field_to_move ] );
 
 		Save::parse( $post, $fields, $settings );
+
+		$updated = get_post( $post->ID );
+		if ( ! $updated ) {
+			return [
+				'success' => false,
+				'message' => __( 'Failed to move field.', 'meta-box-builder' ),
+			];
+		}
 
 		return [
 			'success' => true,
@@ -963,9 +1031,14 @@ class FieldGroupAbilities {
 		return empty( $json );
 	}
 
-	private function build_field_group_summary( \WP_Post $post ): array {
-		$fields = get_post_meta( $post->ID, 'fields', true ) ?: [];
-
+	/**
+	 * Build a lightweight summary array for a field group.
+	 *
+	 * @param \WP_Post $post   The field group post object.
+	 * @param array    $fields The field definitions.
+	 * @return array
+	 */
+	private function build_field_group_summary( \WP_Post $post, array $fields = [] ): array {
 		return [
 			'id'          => $post->ID,
 			'title'       => $post->post_title,
@@ -978,10 +1051,11 @@ class FieldGroupAbilities {
 	}
 
 	private function build_field_group_response( \WP_Post $post ): array {
-		$summary = $this->build_field_group_summary( $post );
+		$fields  = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$summary = $this->build_field_group_summary( $post, $fields );
 
 		return array_merge( $summary, [
-			'fields'   => array_values( get_post_meta( $post->ID, 'fields', true ) ?: [] ),
+			'fields'   => array_values( $fields ),
 			'settings' => get_post_meta( $post->ID, 'settings', true ) ?: [],
 		] );
 	}
@@ -1022,9 +1096,13 @@ class FieldGroupAbilities {
 	 *
 	 * Existing keys not in the new settings are preserved.
 	 * Nested arrays are merged recursively.
+	 *
+	 * @param array $existing The existing settings.
+	 * @param array $incoming The new settings to merge.
+	 * @return array
 	 */
-	private function merge_settings( array $existing, array $new ): array {
-		foreach ( $new as $key => $value ) {
+	private function merge_settings( array $existing, array $incoming ): array {
+		foreach ( $incoming as $key => $value ) {
 			if ( is_array( $value ) && isset( $existing[ $key ] ) && is_array( $existing[ $key ] ) ) {
 				$existing[ $key ] = $this->merge_settings( $existing[ $key ], $value );
 			} else {
@@ -1041,15 +1119,20 @@ class FieldGroupAbilities {
 	 * Existing fields not in the new list are preserved.
 	 * Fields with matching IDs are updated.
 	 * New fields are appended.
+	 * For group-type fields, sub-fields are merged recursively.
+	 *
+	 * @param array $existing The existing fields.
+	 * @param array $incoming The new fields to merge.
+	 * @return array
 	 */
-	private function merge_fields( array $existing, array $new ): array {
-		if ( empty( $new ) ) {
+	private function merge_fields( array $existing, array $incoming ): array {
+		if ( empty( $incoming ) ) {
 			return $existing;
 		}
 
 		$new_by_id = [];
-		foreach ( $new as $field ) {
-			$id = $field['_id'] ?? $field['id'] ?? '';
+		foreach ( $incoming as $field ) {
+			$id = $field['id'] ?? $field['_id'] ?? '';
 			if ( $id ) {
 				$new_by_id[ $id ] = $field;
 			}
@@ -1057,9 +1140,14 @@ class FieldGroupAbilities {
 
 		$merged = [];
 		foreach ( $existing as $field ) {
-			$id = $field['_id'] ?? $field['id'] ?? '';
+			$id = $field['id'] ?? $field['_id'] ?? '';
 			if ( isset( $new_by_id[ $id ] ) ) {
-				$merged[] = $new_by_id[ $id ];
+				$merged_field = $new_by_id[ $id ];
+				if ( ( $merged_field['type'] ?? '' ) === 'group' && isset( $merged_field['fields'] ) ) {
+					$existing_sub           = $field['fields'] ?? [];
+					$merged_field['fields'] = $this->merge_fields( $existing_sub, $merged_field['fields'] );
+				}
+				$merged[] = $merged_field;
 				unset( $new_by_id[ $id ] );
 			} else {
 				$merged[] = $field;

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -593,8 +593,8 @@ class FieldGroupAbilities {
 	public function list_field_groups( array $input ): array {
 		$search   = $input['search'] ?? '';
 		$status   = $input['status'] ?? 'publish';
-		$per_page = $input['per_page'] ?? 20;
-		$page     = $input['page'] ?? 1;
+		$per_page = max( 1, min( 100, (int) ( $input['per_page'] ?? 20 ) ) );
+		$page     = max( 1, (int) ( $input['page'] ?? 1 ) );
 
 		$args = [
 			'post_type'              => 'meta-box',
@@ -853,15 +853,18 @@ class FieldGroupAbilities {
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		$found = false;
-		foreach ( $fields as &$f ) {
-			if ( ( $f['id'] ?? '' ) === $field_id ) {
-				$f     = $this->merge_settings( $f, $field_data );
-				$found = true;
+		$new_id = $field_data['id'] ?? $field_id;
+
+		$found       = false;
+		$found_index = -1;
+		foreach ( $fields as $index => $f ) {
+			$existing_id = $f['id'] ?? $f['_id'] ?? '';
+			if ( $existing_id === $field_id ) {
+				$found       = true;
+				$found_index = $index;
 				break;
 			}
 		}
-		unset( $f );
 
 		if ( ! $found ) {
 			return [
@@ -870,10 +873,13 @@ class FieldGroupAbilities {
 			];
 		}
 
-		$new_id = $field_data['id'] ?? $field_id;
 		if ( $new_id !== $field_id ) {
-			foreach ( $fields as $f ) {
-				if ( ( $f['id'] ?? '' ) === $new_id ) {
+			foreach ( $fields as $index => $f ) {
+				if ( $index === $found_index ) {
+					continue;
+				}
+				$existing_id = $f['id'] ?? $f['_id'] ?? '';
+				if ( $existing_id === $new_id ) {
 					return [
 						'success' => false,
 						'message' => sprintf(
@@ -884,6 +890,14 @@ class FieldGroupAbilities {
 					];
 				}
 			}
+		}
+
+		if ( ( $field_data['type'] ?? '' ) === 'group' && isset( $field_data['fields'] ) ) {
+			$existing_sub                     = $fields[ $found_index ]['fields'] ?? [];
+			$fields[ $found_index ]           = $this->merge_settings( $fields[ $found_index ], $field_data );
+			$fields[ $found_index ]['fields'] = $this->merge_fields( $existing_sub, $field_data['fields'] );
+		} else {
+			$fields[ $found_index ] = $this->merge_settings( $fields[ $found_index ], $field_data );
 		}
 
 		Save::parse( $post, $fields, $settings );
@@ -965,7 +979,15 @@ class FieldGroupAbilities {
 		}
 
 		$target_id = $input['before'] ?? $input['after'] ?? null;
-		$position  = -1;
+
+		if ( $target_id !== null && $target_id === $input['field_id'] ) {
+			return [
+				'success' => false,
+				'message' => __( 'Cannot move a field relative to itself.', 'meta-box-builder' ),
+			];
+		}
+
+		$position = -1;
 
 		if ( $target_id !== null ) {
 			foreach ( $fields as $index => $f ) {
@@ -1149,9 +1171,13 @@ class FieldGroupAbilities {
 			$id = $field['id'] ?? $field['_id'] ?? '';
 			if ( isset( $new_by_id[ $id ] ) ) {
 				$merged_field = $new_by_id[ $id ];
-				if ( ( $merged_field['type'] ?? '' ) === 'group' && isset( $merged_field['fields'] ) ) {
-					$existing_sub           = $field['fields'] ?? [];
-					$merged_field['fields'] = $this->merge_fields( $existing_sub, $merged_field['fields'] );
+				if ( ( $merged_field['type'] ?? '' ) === 'group' ) {
+					$existing_sub = $field['fields'] ?? [];
+					if ( isset( $merged_field['fields'] ) ) {
+						$merged_field['fields'] = $this->merge_fields( $existing_sub, $merged_field['fields'] );
+					} else {
+						$merged_field['fields'] = $existing_sub;
+					}
 				}
 				$merged[] = $merged_field;
 				unset( $new_by_id[ $id ] );

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -176,8 +176,12 @@ class FieldGroupAbilities {
 						'enum'        => [ 'publish', 'draft' ],
 					],
 					'fields'   => [
-						'type'  => 'array',
-						'items' => [ 'type' => 'object' ],
+						'type'        => 'array',
+						'description' => __( 'Array of field definitions. See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'items'       => [
+							'type'                 => 'object',
+							'additionalProperties' => true,
+						],
 					],
 					'settings' => [
 						'type' => 'object',
@@ -235,8 +239,12 @@ class FieldGroupAbilities {
 						'enum'        => [ 'publish', 'draft' ],
 					],
 					'fields'   => [
-						'type'  => 'array',
-						'items' => [ 'type' => 'object' ],
+						'type'        => 'array',
+						'description' => __( 'Array of field definitions. See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'items'       => [
+							'type'                 => 'object',
+							'additionalProperties' => true,
+						],
 					],
 					'settings' => [
 						'type' => 'object',
@@ -401,13 +409,14 @@ class FieldGroupAbilities {
 						'type' => 'integer',
 					],
 					'field'          => [
-						'type'        => 'object',
-						'description' => __( 'The field definition. Must include id, type, and name.', 'meta-box-builder' ),
-						'properties'  => [
+						'type'                 => 'object',
+						'description'          => __( 'Field definition. Must include id, type, name. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
 							'name' => [ 'type' => 'string' ],
 						],
+						'additionalProperties' => true,
 					],
 				],
 				'required'   => [ 'field_group_id', 'field' ],
@@ -447,13 +456,14 @@ class FieldGroupAbilities {
 						'type' => 'integer',
 					],
 					'field'          => [
-						'type'        => 'object',
-						'description' => __( 'The field definition. Must include id.', 'meta-box-builder' ),
-						'properties'  => [
+						'type'                 => 'object',
+						'description'          => __( 'Field definition. Must include id. Accepts all Meta Box field properties (e.g. address_field, options, std, placeholder, required, etc.). See https://github.com/wpmetabox/schema/blob/main/field-group.json for full schema.', 'meta-box-builder' ),
+						'properties'           => [
 							'id'   => [ 'type' => 'string' ],
 							'type' => [ 'type' => 'string' ],
 							'name' => [ 'type' => 'string' ],
 						],
+						'additionalProperties' => true,
 					],
 				],
 				'required'   => [ 'field_group_id', 'field' ],

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -635,8 +635,8 @@ class FieldGroupAbilities {
 	 * @return array|WP_Error
 	 */
 	public function get_field_group( array $input ) {
-		$post = get_post( $input['id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['id'] );
+		if ( ! $post ) {
 			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
@@ -662,23 +662,15 @@ class FieldGroupAbilities {
 			return $this->error( $post_id->get_error_message(), [ 'id' => 0 ] );
 		}
 
-		$request = new WP_REST_Request( 'POST', '/mbb/save' );
-		$request->set_param( 'post_id', $post_id );
-		$request->set_param( 'post_title', $title );
-		$request->set_param( 'post_name', $slug );
-		$request->set_param( 'fields', $fields );
-		$request->set_param( 'settings', $settings );
-
-		$save   = new Save();
-		$result = $save->save( $request );
+		$result = $this->save_field_group( $post_id, $title, $slug, $fields, $settings );
 
 		return array_merge( $result, [ 'id' => $post_id ] );
 	}
 
 	public function update_field_group( array $input ): array {
 		$post_id = $input['id'];
-		$post    = get_post( $post_id );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post    = $this->get_field_group_post( $post_id );
+		if ( ! $post ) {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
@@ -694,15 +686,7 @@ class FieldGroupAbilities {
 		$fields   = $this->merge_fields( $existing_fields, $unparsed['fields'] );
 		$settings = $this->merge_settings( $existing_settings, $unparsed['settings'] );
 
-		$request = new WP_REST_Request( 'POST', '/mbb/save' );
-		$request->set_param( 'post_id', $post_id );
-		$request->set_param( 'post_title', $title );
-		$request->set_param( 'post_name', $slug );
-		$request->set_param( 'fields', $fields );
-		$request->set_param( 'settings', $settings );
-
-		$save   = new Save();
-		$result = $save->save( $request );
+		$result = $this->save_field_group( $post_id, $title, $slug, $fields, $settings );
 
 		if ( ! empty( $result['success'] ) && $has_status && $status !== $post->post_status ) {
 			wp_update_post( [
@@ -715,8 +699,8 @@ class FieldGroupAbilities {
 	}
 
 	public function delete_field_group( array $input ): array {
-		$post = get_post( $input['id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['id'] );
+		if ( ! $post ) {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
@@ -745,8 +729,8 @@ class FieldGroupAbilities {
 	 * @return array|WP_Error
 	 */
 	public function list_fields( array $input ) {
-		$post = get_post( $input['field_group_id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['field_group_id'] );
+		if ( ! $post ) {
 			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
@@ -766,25 +750,24 @@ class FieldGroupAbilities {
 	 * @return array|WP_Error
 	 */
 	public function get_field( array $input ) {
-		$post = get_post( $input['field_group_id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['field_group_id'] );
+		if ( ! $post ) {
 			return new WP_Error( 'not_found', __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$fields = get_post_meta( $post->ID, 'fields', true ) ?: [];
-		foreach ( $fields as $field ) {
-			$id = $field['id'] ?? $field['_id'] ?? '';
-			if ( $id === $input['field_id'] ) {
-				return [ 'field' => $field ];
-			}
+		$index  = $this->find_field_index( $fields, $input['field_id'] );
+
+		if ( $index === -1 ) {
+			return new WP_Error( 'not_found', __( 'Field not found.', 'meta-box-builder' ) );
 		}
 
-		return new WP_Error( 'not_found', __( 'Field not found.', 'meta-box-builder' ) );
+		return [ 'field' => $fields[ $index ] ];
 	}
 
 	public function create_field( array $input ): array {
-		$post = get_post( $input['field_group_id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['field_group_id'] );
+		if ( ! $post ) {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
@@ -796,11 +779,9 @@ class FieldGroupAbilities {
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		foreach ( $fields as $f ) {
-			$existing_id = $f['id'] ?? $f['_id'] ?? '';
-			if ( $existing_id === $field_data['id'] ) {
-				return $this->error( __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ) );
-			}
+		$existing_index = $this->find_field_index( $fields, $field_data['id'] );
+		if ( $existing_index !== -1 ) {
+			return $this->error( __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ) );
 		}
 
 		$fields[] = $field_data;
@@ -810,8 +791,8 @@ class FieldGroupAbilities {
 	}
 
 	public function update_field( array $input ): array {
-		$post = get_post( $input['field_group_id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['field_group_id'] );
+		if ( ! $post ) {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
@@ -822,32 +803,16 @@ class FieldGroupAbilities {
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
 		$new_id = $field_data['id'] ?? $field_id;
+		$found_index = $this->find_field_index( $fields, $field_id );
 
-		$found       = false;
-		$found_index = -1;
-		foreach ( $fields as $index => $f ) {
-			$existing_id = $f['id'] ?? $f['_id'] ?? '';
-			if ( $existing_id === $field_id ) {
-				$found       = true;
-				$found_index = $index;
-				break;
-			}
-		}
-
-		if ( ! $found ) {
+		if ( $found_index === -1 ) {
 			return $this->error( __( 'Field not found. Use create field instead.', 'meta-box-builder' ) );
 		}
 
-		// Check if update field id to an existing field id.
+		// Check if renaming to an existing field ID.
 		if ( $new_id !== $field_id ) {
-			foreach ( $fields as $index => $f ) {
-				if ( $index === $found_index ) {
-					continue;
-				}
-				$existing_id = $f['id'] ?? $f['_id'] ?? '';
-				if ( $existing_id !== $new_id ) {
-					continue;
-				}
+			$collision_index = $this->find_field_index( $fields, $new_id );
+			if ( $collision_index !== -1 && $collision_index !== $found_index ) {
 				return $this->error( sprintf(
 					/* translators: %s: The new field ID. */
 					__( 'Another field with ID %s already exists.', 'meta-box-builder' ),
@@ -868,50 +833,36 @@ class FieldGroupAbilities {
 	}
 
 	public function delete_field( array $input ): array {
-		$post = get_post( $input['field_group_id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['field_group_id'] );
+		if ( ! $post ) {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		$original_count = count( $fields );
-		$fields         = array_values( array_filter( $fields, function ( $f ) use ( $input ) {
-			$id = $f['id'] ?? $f['_id'] ?? '';
-			return $id !== $input['field_id'];
-		} ) );
-
-		if ( count( $fields ) === $original_count ) {
+		$index = $this->find_field_index( $fields, $input['field_id'] );
+		if ( $index === -1 ) {
 			return $this->error( __( 'Field not found.', 'meta-box-builder' ) );
 		}
 
+		array_splice( $fields, $index, 1 );
 		Save::parse( $post, $fields, $settings );
 
 		return $this->success( __( 'Field deleted successfully.', 'meta-box-builder' ) );
 	}
 
 	public function move_field( array $input ): array {
-		$post = get_post( $input['field_group_id'] );
-		if ( ! $post || $post->post_type !== 'meta-box' ) {
+		$post = $this->get_field_group_post( $input['field_group_id'] );
+		if ( ! $post ) {
 			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
-		$field_to_move = null;
-		$field_index   = -1;
-		foreach ( $fields as $index => $f ) {
-			$id = $f['id'] ?? $f['_id'] ?? '';
-			if ( $id === $input['field_id'] ) {
-				$field_to_move = $f;
-				$field_index   = $index;
-				break;
-			}
-		}
-
-		if ( ! $field_to_move ) {
+		$field_index = $this->find_field_index( $fields, $input['field_id'] );
+		if ( $field_index === -1 ) {
 			return $this->error( __( 'Field not found.', 'meta-box-builder' ) );
 		}
 
@@ -925,42 +876,31 @@ class FieldGroupAbilities {
 			return $this->error( __( 'Cannot move a field relative to itself.', 'meta-box-builder' ) );
 		}
 
-		$position = -1;
-
 		if ( $target_id !== null ) {
-			foreach ( $fields as $index => $f ) {
-				$id = $f['id'] ?? $f['_id'] ?? '';
-				if ( $id === $target_id ) {
-					$position = isset( $input['before'] ) ? $index : $index + 1;
-					break;
-				}
-			}
-
-			if ( $position === -1 ) {
+			$target_index = $this->find_field_index( $fields, $target_id );
+			if ( $target_index === -1 ) {
 				return $this->error( sprintf(
 					/* translators: %s: The field ID to move before/after. */
 					__( 'Target field %s not found.', 'meta-box-builder' ),
 					$target_id
 				) );
 			}
+			$position = isset( $input['before'] ) ? $target_index : $target_index + 1;
 		} else {
 			$position = count( $fields );
 		}
 
 		// Check if the field is already at the target position (no-op).
-		$current_index = $field_index;
-		$target_index  = $position;
-		if ( $target_index > $current_index ) {
+		$target_index = $position;
+		if ( $target_index > $field_index ) {
 			--$target_index;
 		}
-		if ( $current_index === $target_index ) {
+		if ( $field_index === $target_index ) {
 			return $this->success( __( 'Field is already at the target position.', 'meta-box-builder' ) );
 		}
 
-		// Remove the field from its current position.
+		$field_to_move = $fields[ $field_index ];
 		array_splice( $fields, $field_index, 1 );
-
-		// Insert at the target position.
 		array_splice( $fields, $target_index, 0, [ $field_to_move ] );
 
 		Save::parse( $post, $fields, $settings );
@@ -971,6 +911,34 @@ class FieldGroupAbilities {
 	/**
 	 * Helpers.
 	 */
+	private function get_field_group_post( int $id ): ?\WP_Post {
+		$post = get_post( $id );
+
+		return $post && $post->post_type === 'meta-box' ? $post : null;
+	}
+
+	private function find_field_index( array $fields, string $field_id ): int {
+		foreach ( $fields as $index => $field ) {
+			$id = $field['id'] ?? $field['_id'] ?? '';
+			if ( $id === $field_id ) {
+				return $index;
+			}
+		}
+
+		return -1;
+	}
+
+	private function save_field_group( int $post_id, string $title, string $slug, array $fields, array $settings ): array {
+		$request = new WP_REST_Request( 'POST', '/mbb/save' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'post_title', $title );
+		$request->set_param( 'post_name', $slug );
+		$request->set_param( 'fields', $fields );
+		$request->set_param( 'settings', $settings );
+
+		return ( new Save() )->save( $request );
+	}
+
 	private function success( string $message, array $extra = [] ): array {
 		return array_merge( [
 			'success' => true,

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -132,6 +132,7 @@ class FieldGroupAbilities {
 					'title'       => [ 'type' => 'string' ],
 					'slug'        => [ 'type' => 'string' ],
 					'status'      => [ 'type' => 'string' ],
+					'field_count' => [ 'type' => 'integer' ],
 					'fields'      => [
 						'type'  => 'array',
 						'items' => [ 'type' => 'object' ],
@@ -658,11 +659,7 @@ class FieldGroupAbilities {
 		] );
 
 		if ( is_wp_error( $post_id ) ) {
-			return [
-				'success' => false,
-				'message' => $post_id->get_error_message(),
-				'id'      => 0,
-			];
+			return $this->error( $post_id->get_error_message(), [ 'id' => 0 ] );
 		}
 
 		$request = new WP_REST_Request( 'POST', '/mbb/save' );
@@ -682,10 +679,7 @@ class FieldGroupAbilities {
 		$post_id = $input['id'];
 		$post    = get_post( $post_id );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$unparsed   = $this->unparse_input( $input );
@@ -723,36 +717,25 @@ class FieldGroupAbilities {
 	public function delete_field_group( array $input ): array {
 		$post = get_post( $input['id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$force = $input['force'] ?? false;
 
 		if ( ! $force && $post->post_status === 'trash' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group is already in trash.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group is already in trash.', 'meta-box-builder' ) );
 		}
 
 		$result = wp_delete_post( $post->ID, $force );
 
 		if ( ! $result ) {
-			return [
-				'success' => false,
-				'message' => __( 'Failed to delete field group.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Failed to delete field group.', 'meta-box-builder' ) );
 		}
 
-		return [
-			'success' => true,
-			'message' => $force
-				? __( 'Field group permanently deleted.', 'meta-box-builder' )
-				: __( 'Field group moved to trash.', 'meta-box-builder' ),
-		];
+		return $this->success( $force
+			? __( 'Field group permanently deleted.', 'meta-box-builder' )
+			: __( 'Field group moved to trash.', 'meta-box-builder' )
+		);
 	}
 
 	/**
@@ -802,18 +785,12 @@ class FieldGroupAbilities {
 	public function create_field( array $input ): array {
 		$post = get_post( $input['field_group_id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$field_data = $this->unparse_field( $input['field'] );
 		if ( empty( $field_data['id'] ) || empty( $field_data['type'] ) ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field must have id and type.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field must have id and type.', 'meta-box-builder' ) );
 		}
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
@@ -822,29 +799,20 @@ class FieldGroupAbilities {
 		foreach ( $fields as $f ) {
 			$existing_id = $f['id'] ?? $f['_id'] ?? '';
 			if ( $existing_id === $field_data['id'] ) {
-				return [
-					'success' => false,
-					'message' => __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ),
-				];
+				return $this->error( __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ) );
 			}
 		}
 
 		$fields[] = $field_data;
 		Save::parse( $post, $fields, $settings );
 
-		return [
-			'success' => true,
-			'message' => __( 'Field added successfully.', 'meta-box-builder' ),
-		];
+		return $this->success( __( 'Field added successfully.', 'meta-box-builder' ) );
 	}
 
 	public function update_field( array $input ): array {
 		$post = get_post( $input['field_group_id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$field_data = $this->unparse_field( $input['field'] );
@@ -867,10 +835,7 @@ class FieldGroupAbilities {
 		}
 
 		if ( ! $found ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field not found. Use create field instead.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field not found. Use create field instead.', 'meta-box-builder' ) );
 		}
 
 		// Check if update field id to an existing field id.
@@ -883,14 +848,11 @@ class FieldGroupAbilities {
 				if ( $existing_id !== $new_id ) {
 					continue;
 				}
-				return [
-					'success' => false,
-					'message' => sprintf(
-						/* translators: %s: The new field ID. */
-						__( 'Another field with ID %s already exists.', 'meta-box-builder' ),
-						$new_id
-					),
-				];
+				return $this->error( sprintf(
+					/* translators: %s: The new field ID. */
+					__( 'Another field with ID %s already exists.', 'meta-box-builder' ),
+					$new_id
+				) );
 			}
 		}
 
@@ -902,19 +864,13 @@ class FieldGroupAbilities {
 
 		Save::parse( $post, $fields, $settings );
 
-		return [
-			'success' => true,
-			'message' => __( 'Field updated successfully.', 'meta-box-builder' ),
-		];
+		return $this->success( __( 'Field updated successfully.', 'meta-box-builder' ) );
 	}
 
 	public function delete_field( array $input ): array {
 		$post = get_post( $input['field_group_id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
@@ -927,27 +883,18 @@ class FieldGroupAbilities {
 		} ) );
 
 		if ( count( $fields ) === $original_count ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field not found.', 'meta-box-builder' ) );
 		}
 
 		Save::parse( $post, $fields, $settings );
 
-		return [
-			'success' => true,
-			'message' => __( 'Field deleted successfully.', 'meta-box-builder' ),
-		];
+		return $this->success( __( 'Field deleted successfully.', 'meta-box-builder' ) );
 	}
 
 	public function move_field( array $input ): array {
 		$post = get_post( $input['field_group_id'] );
 		if ( ! $post || $post->post_type !== 'meta-box' ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field group not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field group not found.', 'meta-box-builder' ) );
 		}
 
 		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
@@ -965,26 +912,17 @@ class FieldGroupAbilities {
 		}
 
 		if ( ! $field_to_move ) {
-			return [
-				'success' => false,
-				'message' => __( 'Field not found.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Field not found.', 'meta-box-builder' ) );
 		}
 
 		if ( isset( $input['before'] ) && isset( $input['after'] ) ) {
-			return [
-				'success' => false,
-				'message' => __( 'Only one of before or after may be specified.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Only one of before or after may be specified.', 'meta-box-builder' ) );
 		}
 
 		$target_id = $input['before'] ?? $input['after'] ?? null;
 
 		if ( $target_id !== null && $target_id === $input['field_id'] ) {
-			return [
-				'success' => false,
-				'message' => __( 'Cannot move a field relative to itself.', 'meta-box-builder' ),
-			];
+			return $this->error( __( 'Cannot move a field relative to itself.', 'meta-box-builder' ) );
 		}
 
 		$position = -1;
@@ -999,14 +937,11 @@ class FieldGroupAbilities {
 			}
 
 			if ( $position === -1 ) {
-				return [
-					'success' => false,
-					'message' => sprintf(
-						/* translators: %s: The field ID to move before/after. */
-						__( 'Target field %s not found.', 'meta-box-builder' ),
-						$target_id
-					),
-				];
+				return $this->error( sprintf(
+					/* translators: %s: The field ID to move before/after. */
+					__( 'Target field %s not found.', 'meta-box-builder' ),
+					$target_id
+				) );
 			}
 		} else {
 			$position = count( $fields );
@@ -1019,10 +954,7 @@ class FieldGroupAbilities {
 			--$target_index;
 		}
 		if ( $current_index === $target_index ) {
-			return [
-				'success' => true,
-				'message' => __( 'Field is already at the target position.', 'meta-box-builder' ),
-			];
+			return $this->success( __( 'Field is already at the target position.', 'meta-box-builder' ) );
 		}
 
 		// Remove the field from its current position.
@@ -1033,15 +965,26 @@ class FieldGroupAbilities {
 
 		Save::parse( $post, $fields, $settings );
 
-		return [
-			'success' => true,
-			'message' => __( 'Field moved successfully.', 'meta-box-builder' ),
-		];
+		return $this->success( __( 'Field moved successfully.', 'meta-box-builder' ) );
 	}
 
 	/**
 	 * Helpers.
 	 */
+	private function success( string $message, array $extra = [] ): array {
+		return array_merge( [
+			'success' => true,
+			'message' => $message,
+		], $extra );
+	}
+
+	private function error( string $message, array $extra = [] ): array {
+		return array_merge( [
+			'success' => false,
+			'message' => $message,
+		], $extra );
+	}
+
 	public function permission_callback(): bool {
 		return current_user_can( 'manage_options' );
 	}

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -616,7 +616,8 @@ class FieldGroupAbilities {
 			if ( ! $this->is_database_only( $post ) ) {
 				continue;
 			}
-			$groups[] = $this->build_field_group_summary( $post );
+			$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+			$groups[] = $this->build_field_group_summary( $post, $fields );
 		}
 
 		return [
@@ -687,10 +688,11 @@ class FieldGroupAbilities {
 			];
 		}
 
-		$unparsed = $this->unparse_input( $input );
-		$title    = $unparsed['title'] ?: $post->post_title;
-		$slug     = $unparsed['slug'] ?: $post->post_name;
-		$status   = $unparsed['status'] ?? null;
+		$unparsed   = $this->unparse_input( $input );
+		$title      = $unparsed['title'] ?: $post->post_title;
+		$slug       = $unparsed['slug'] ?: $post->post_name;
+		$has_status = array_key_exists( 'status', $input ) || array_key_exists( 'status', $unparsed );
+		$status     = $unparsed['status'] ?? null;
 
 		$existing_fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
 		$existing_settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
@@ -708,7 +710,7 @@ class FieldGroupAbilities {
 		$save   = new Save();
 		$result = $save->save( $request );
 
-		if ( ! empty( $result['success'] ) && $status !== null && $status !== $post->post_status ) {
+		if ( ! empty( $result['success'] ) && $has_status && $status !== $post->post_status ) {
 			wp_update_post( [
 				'ID'          => $post_id,
 				'post_status' => $status,
@@ -727,7 +729,15 @@ class FieldGroupAbilities {
 			];
 		}
 
-		$force  = $input['force'] ?? false;
+		$force = $input['force'] ?? false;
+
+		if ( ! $force && $post->post_status === 'trash' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group is already in trash.', 'meta-box-builder' ),
+			];
+		}
+
 		$result = wp_delete_post( $post->ID, $force );
 
 		if ( ! $result ) {
@@ -809,7 +819,8 @@ class FieldGroupAbilities {
 		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
 
 		foreach ( $fields as $f ) {
-			if ( ( $f['id'] ?? '' ) === $field_data['id'] ) {
+			$existing_id = $f['id'] ?? $f['_id'] ?? '';
+			if ( $existing_id === $field_data['id'] ) {
 				return [
 					'success' => false,
 					'message' => __( 'Field with this ID already exists. Use update field instead.', 'meta-box-builder' ),
@@ -819,14 +830,6 @@ class FieldGroupAbilities {
 
 		$fields[] = $field_data;
 		Save::parse( $post, $fields, $settings );
-
-		$updated = get_post( $post->ID );
-		if ( ! $updated ) {
-			return [
-				'success' => false,
-				'message' => __( 'Failed to save field.', 'meta-box-builder' ),
-			];
-		}
 
 		return [
 			'success' => true,
@@ -852,7 +855,7 @@ class FieldGroupAbilities {
 		$found = false;
 		foreach ( $fields as &$f ) {
 			if ( ( $f['id'] ?? '' ) === $field_id ) {
-				$f     = array_merge( $f, $field_data );
+				$f     = $this->merge_settings( $f, $field_data );
 				$found = true;
 				break;
 			}
@@ -866,15 +869,23 @@ class FieldGroupAbilities {
 			];
 		}
 
-		Save::parse( $post, $fields, $settings );
-
-		$updated = get_post( $post->ID );
-		if ( ! $updated ) {
-			return [
-				'success' => false,
-				'message' => __( 'Failed to save field.', 'meta-box-builder' ),
-			];
+		$new_id = $field_data['id'] ?? $field_id;
+		if ( $new_id !== $field_id ) {
+			foreach ( $fields as $f ) {
+				if ( ( $f['id'] ?? '' ) === $new_id ) {
+					return [
+						'success' => false,
+						'message' => sprintf(
+							/* translators: %s: The new field ID. */
+							__( 'Another field with ID %s already exists.', 'meta-box-builder' ),
+							$new_id
+						),
+					];
+				}
+			}
 		}
+
+		Save::parse( $post, $fields, $settings );
 
 		return [
 			'success' => true,
@@ -908,14 +919,6 @@ class FieldGroupAbilities {
 
 		Save::parse( $post, $fields, $settings );
 
-		$updated = get_post( $post->ID );
-		if ( ! $updated ) {
-			return [
-				'success' => false,
-				'message' => __( 'Failed to delete field.', 'meta-box-builder' ),
-			];
-		}
-
 		return [
 			'success' => true,
 			'message' => __( 'Field deleted successfully.', 'meta-box-builder' ),
@@ -948,6 +951,13 @@ class FieldGroupAbilities {
 			return [
 				'success' => false,
 				'message' => __( 'Field not found.', 'meta-box-builder' ),
+			];
+		}
+
+		if ( isset( $input['before'] ) && isset( $input['after'] ) ) {
+			return [
+				'success' => false,
+				'message' => __( 'Only one of before or after may be specified.', 'meta-box-builder' ),
 			];
 		}
 
@@ -996,14 +1006,6 @@ class FieldGroupAbilities {
 		array_splice( $fields, $target_index, 0, [ $field_to_move ] );
 
 		Save::parse( $post, $fields, $settings );
-
-		$updated = get_post( $post->ID );
-		if ( ! $updated ) {
-			return [
-				'success' => false,
-				'message' => __( 'Failed to move field.', 'meta-box-builder' ),
-			];
-		}
 
 		return [
 			'success' => true,

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -822,12 +822,12 @@ class FieldGroupAbilities {
 			}
 		}
 
-		$fields[ $found_index ] = $this->merge_settings( $fields[ $found_index ], $field_data );
-		$fields[ $found_index ] = $this->ensure_unique_field_id( $fields[ $found_index ], $fields, $found_index );
-		if ( ( $field_data['type'] ?? '' ) === 'group' && isset( $field_data['fields'] ) ) {
-			$existing_sub                     = $fields[ $found_index ]['fields'] ?? [];
-			$fields[ $found_index ]['fields'] = $this->merge_fields( $existing_sub, $field_data['fields'] );
+		$replaced = array_replace( $fields[ $found_index ], $field_data );
+		if ( isset( $field_data['fields'] ) ) {
+			$existing_sub       = $fields[ $found_index ]['fields'] ?? [];
+			$replaced['fields'] = $this->merge_fields( $existing_sub, $field_data['fields'] );
 		}
+		$fields[ $found_index ] = $this->ensure_unique_field_id( $replaced, $fields, $found_index );
 
 		Save::parse( $post, $fields, $settings );
 

--- a/src/Abilities/FieldGroupAbilities.php
+++ b/src/Abilities/FieldGroupAbilities.php
@@ -41,6 +41,7 @@ class FieldGroupAbilities {
 		$this->register_create_field();
 		$this->register_update_field();
 		$this->register_delete_field();
+		$this->register_move_field();
 	}
 
 	private function register_list_field_groups(): void {
@@ -537,6 +538,55 @@ class FieldGroupAbilities {
 		] );
 	}
 
+	private function register_move_field(): void {
+		wp_register_ability( 'meta-box/move-field', [
+			'label'               => __( 'Move field', 'meta-box-builder' ),
+			'description'         => __( 'Move a field to a new position within a field group. Specify before or after a reference field ID.', 'meta-box-builder' ),
+			'category'            => self::CATEGORY,
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'field_group_id' => [
+						'type' => 'integer',
+					],
+					'field_id'       => [
+						'type'        => 'string',
+						'description' => __( 'The field ID to move.', 'meta-box-builder' ),
+					],
+					'before'         => [
+						'type'        => 'string',
+						'description' => __( 'Move before this field ID.', 'meta-box-builder' ),
+					],
+					'after'          => [
+						'type'        => 'string',
+						'description' => __( 'Move after this field ID.', 'meta-box-builder' ),
+					],
+				],
+				'required'   => [ 'field_group_id', 'field_id' ],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'success' => [ 'type' => 'boolean' ],
+					'message' => [ 'type' => 'string' ],
+				],
+			],
+			'execute_callback'    => [ $this, 'move_field' ],
+			'permission_callback' => [ $this, 'permission_callback' ],
+			'meta'                => [
+				'annotations' => [
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'         => [
+					'public' => true,
+					'type'   => 'tool',
+				],
+			],
+		] );
+	}
+
 	/**
 	 * Execute callbacks.
 	 */
@@ -832,6 +882,64 @@ class FieldGroupAbilities {
 		return [
 			'success' => true,
 			'message' => __( 'Field deleted successfully.', 'meta-box-builder' ),
+		];
+	}
+
+	public function move_field( array $input ): array {
+		$post = get_post( $input['field_group_id'] );
+		if ( ! $post || $post->post_type !== 'meta-box' ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field group not found.', 'meta-box-builder' ),
+			];
+		}
+
+		$fields   = get_post_meta( $post->ID, 'fields', true ) ?: [];
+		$settings = get_post_meta( $post->ID, 'settings', true ) ?: [];
+
+		$field_to_move = null;
+		$field_index   = -1;
+		foreach ( $fields as $index => $f ) {
+			if ( ( $f['id'] ?? '' ) === $input['field_id'] ) {
+				$field_to_move = $f;
+				$field_index   = $index;
+				break;
+			}
+		}
+
+		if ( ! $field_to_move ) {
+			return [
+				'success' => false,
+				'message' => __( 'Field not found.', 'meta-box-builder' ),
+			];
+		}
+
+		// Remove the field from its current position.
+		array_splice( $fields, $field_index, 1 );
+
+		// Find the target position.
+		$target_id = $input['before'] ?? $input['after'] ?? '';
+		$position  = -1;
+		foreach ( $fields as $index => $f ) {
+			if ( ( $f['id'] ?? '' ) === $target_id ) {
+				$position = $input['before'] ?? '' ? $index : $index + 1;
+				break;
+			}
+		}
+
+		// If target not found or not specified, append to end.
+		if ( $position === -1 ) {
+			$position = count( $fields );
+		}
+
+		// Insert at the target position.
+		array_splice( $fields, $position, 0, [ $field_to_move ] );
+
+		Save::parse( $post, $fields, $settings );
+
+		return [
+			'success' => true,
+			'message' => __( 'Field moved successfully.', 'meta-box-builder' ),
 		];
 	}
 


### PR DESCRIPTION
## Changes

- Add CRUD abilities for field groups and fields (list, get, create, update, delete)
- Add move_field ability for reordering fields within a field group
- Unparse input from parsed schema format to builder format before saving
- Merge fields by ID on update (existing fields preserved)
- Recursively merge settings on update (nested arrays preserved)
- Allow changing field ID on update via field_id parameter

## Abilities

- `meta-box/list-field-groups` - List all field groups
- `meta-box/get-field-group` - Get a field group with fields
- `meta-box/create-field-group` - Create a new field group
- `meta-box/update-field-group` - Update an existing field group
- `meta-box/delete-field-group` - Delete a field group
- `meta-box/list-fields` - List fields in a field group
- `meta-box/get-field` - Get a single field
- `meta-box/create-field` - Add a field to a field group
- `meta-box/update-field` - Update a field (supports changing ID)
- `meta-box/delete-field` - Remove a field
- `meta-box/move-field` - Move a field before/after another field