### PR TITLE
Add block bindings toggle for fields

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -110,6 +110,10 @@ class Registry {
 				'label'       => __( 'HTML after', 'meta-box-builder' ),
 				'description' => __( 'Custom HTML displayed after the field wrapper HTML.', 'meta-box-builder' ),
 			], '', 'advanced' ),
+			Control::Toggle( 'block_bindings', [
+				'label'       => __( 'Enable block bindings?', 'meta-box-builder' ),
+				'description' => __( 'Allow this field to be used as a block binding source in the block editor.', 'meta-box-builder' ),
+			], false, 'advanced' ),
 			Control::Toggle( 'save_field', [
 				'label'       => __( 'Save field value', 'meta-box-builder' ),
 				'description' => __( 'Uncheck this checkbox to prevent the field from saving its value into the database. Use only when you want to save the data yourself with code.', 'meta-box-builder' ),

--- a/src/RestApi/Fields.php
+++ b/src/RestApi/Fields.php
@@ -52,7 +52,7 @@ class Fields extends Base {
 		$general_tab    = [ 'type', 'name', 'id' ];
 		$appearance_tab = [ 'label_description', 'desc' ];
 		$validation_tab = [ 'validation' ];
-		$advanced_tab   = [ 'class', 'before', 'after', 'save_field', 'sanitize_callback', 'attributes', 'custom_settings' ];
+		$advanced_tab   = [ 'class', 'before', 'after', 'block_bindings', 'save_field', 'sanitize_callback', 'attributes', 'custom_settings' ];
 
 		$field_types = [
 			'autocomplete'      => [

--- a/vendor/wpmetabox/mbb-parser/src/Parsers/Field.php
+++ b/vendor/wpmetabox/mbb-parser/src/Parsers/Field.php
@@ -52,6 +52,7 @@ class Field extends Base {
 		'readonly',
 		'hide_from_rest',
 		'hide_from_front',
+		'block_bindings',
 	];
 
 	private $choice_types = [ 'select', 'radio', 'checkbox_list', 'select_advanced', 'button_group', 'image_select', 'autocomplete' ];


### PR DESCRIPTION
Allow fields to opt into Meta Box block bindings from the Advanced tab, and strip the false default on export.